### PR TITLE
Scripts can access their file location

### DIFF
--- a/start.py
+++ b/start.py
@@ -394,7 +394,9 @@ def script_cli():
     with open(filepath, "r") as stream:
         content = stream.read()
 
-    exec(compile(content, filepath, "exec"), globals())
+    script_globals = dict(globals())
+    script_globals["__file__"] = filepath
+    exec(compile(content, filepath, "exec"), script_globals)
 
 
 def get_info(use_staging=None) -> list:


### PR DESCRIPTION
## Changelog Description
Pass `__file__` to executed script so the script can use it.

## Testing notes:
1. Run a script using ayon executable
```python
import os

print(os.abspath(__file__)
```

`./ayon_console.exe {path to script} --skip-bootstrap`
2. Output should print full path to a script
