### PR TITLE
Better dependencies information

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -253,6 +253,7 @@ build_ayon () {
     git submodule update --init --recursive || { echo -e "${BIRed}!!!${RST} Poetry installation failed"; return 1; }
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
+  "$POETRY_HOME/bin/poetry" run python -m pip freeze > "$repo_root/build/requirements.txt"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     "$POETRY_HOME/bin/poetry" run python "$repo_root/setup.py" build &> "$repo_root/build/build.log" || { echo -e "${BIRed}------------------------------------------${RST}"; cat "$repo_root/build/build.log"; echo -e "${BIRed}------------------------------------------${RST}"; echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
   elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -270,7 +270,8 @@ function Build-Ayon($MakeInstaller = $false) {
     Write-Color -Text ">>> ", "Building AYON ..." -Color Green, White
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
-    $out = &  "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
+    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip freeze > "$($repo_root)\build\requirements.txt"
+    $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
     if ($LASTEXITCODE -ne 0)
     {


### PR DESCRIPTION
## Changelog Description
Use pip freeze to get available package versions instead of reading poetry.lock.

## Additional info
Poetry lock does contain packages for all platforms which is unwanted, also pip freeze stores git repositories automatically without manually resolving them from poetry.lock.

## Testing notes:
1. Run build
2. Metadata about build should contain only dependencies that are really available in build and git repositories have git information
