### PR TITLE
Pip requirements fix

### DIFF
--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -365,16 +365,12 @@ def get_packages_info(build_root):
         line = line.strip()
         if not line:
             continue
-        parts = line.split("==")
-        if len(parts) != 2:
-            parts = line.split("@")
-            if len(parts) < 2:
-                raise ValueError(f"Cannot parse package info '{line}'.")
 
-            if len(parts) > 2:
-                parts = [parts[0], "@".join(parts[1:])]
-        package, version = parts
-        packages[package.strip()] = version.strip()
+        match = re.match(r"^(.+?)(?:==|>=|<=|~=|!=|@)(.+)$", line)
+        if not match:
+            raise ValueError(f"Cannot parse package info '{line}'.")
+        package_name, version = match.groups()
+        packages[package_name.rstrip()] = version.lstrip()
 
     return packages
 

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -253,7 +253,7 @@ build_ayon () {
     git submodule update --init --recursive || { echo -e "${BIRed}!!!${RST} Poetry installation failed"; return 1; }
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
-  "$POETRY_HOME/bin/poetry" run python -m pip freeze > "$repo_root/build/requirements.txt"
+  "$POETRY_HOME/bin/poetry" run python -m pip --no-color freeze > "$repo_root/build/requirements.txt"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     "$POETRY_HOME/bin/poetry" run python "$repo_root/setup.py" build &> "$repo_root/build/build.log" || { echo -e "${BIRed}------------------------------------------${RST}"; cat "$repo_root/build/build.log"; echo -e "${BIRed}------------------------------------------${RST}"; echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
   elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -273,7 +273,7 @@ function Build-Ayon($MakeInstaller = $false) {
     Write-Color -Text ">>> ", "Building AYON ..." -Color Green, White
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
-    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip freeze > "$($repo_root)\build\requirements.txt"
+    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze > "$($repo_root)\build\requirements.txt"
     $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
     if ($LASTEXITCODE -ne 0)


### PR DESCRIPTION
## Changelog Description
Force pip to not use colors when calling freeze.

## Additional info
Pip will use color characters during freeze, if has some available, which caused errors when parsing them. Changed how versions are split, instead of manual split is used regex.
