### PR TITLE
Distribution of dependency packages

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1329,7 +1329,7 @@ class AyonDistribution:
             dependenc_package_items = {}
             for item in self.dependency_packages_info:
                 item = DependencyItem.from_dict(item)
-                dependenc_package_items[item.name] = item
+                dependenc_package_items[item.filename] = item
             self._dependency_packages_items = dependenc_package_items
         return self._dependency_packages_items
 
@@ -1430,15 +1430,15 @@ class AyonDistribution:
         metadata = self.get_dependency_metadata()
         downloader_data = {
             "type": "dependency_package",
-            "name": package.name,
+            "name": package.filename,
             "platform": package.platform_name
         }
         zip_dir = package_dir = os.path.join(
-            self._dependency_dirpath, package.name
+            self._dependency_dirpath, package.filename
         )
-        self.log.debug(f"Checking {package.name} in {package_dir}")
+        self.log.debug(f"Checking {package.filename} in {package_dir}")
 
-        if not os.path.isdir(package_dir) or package.name not in metadata:
+        if not os.path.isdir(package_dir) or package.filename not in metadata:
             state = UpdateState.OUTDATED
         else:
             state = UpdateState.UPDATED
@@ -1619,7 +1619,7 @@ class AyonDistribution:
                         dependency_dist_item.checksum_algorithm),
                     "distributed_dt": stored_time
                 }
-                self.update_dependency_metadata(package.name, data)
+                self.update_dependency_metadata(package.filename, data)
 
         addons_info = {}
         for item in self.get_addon_dist_items():

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1734,14 +1734,27 @@ class AyonDistribution:
         ))
 
     def get_sys_paths(self):
+        """Get all paths to python packages that should be added to path.
+
+        These packages will be added only to 'sys.path' and not into
+        'PYTHONPATH', so they won't be available in subprocesses.
+
+        Todos:
+            This is not yet implemented. The goal is that dependency
+                package will contain also 'build' python
+                dependencies (OpenTimelineIO, Pillow, etc.).
+
+        Returns:
+            List[str]: Paths that should be added to 'sys.path'.
+        """
+
+        return []
+
+    def get_python_paths(self):
         """Get all paths to python packages that should be added to python.
 
         These paths lead to addon directories and python dependencies in
         dependency package.
-
-        Todos:
-            Add dependency package directory to output. ATM is not structure of
-                dependency package 100% defined.
 
         Returns:
             List[str]: Paths that should be added to 'sys.path' and
@@ -1749,12 +1762,23 @@ class AyonDistribution:
         """
 
         output = []
-        for item in self.get_all_distribution_items():
-            if item.state != UpdateState.UPDATED:
+        for item in self.get_addon_dist_items():
+            dist_item = item["dist_item"]
+            if dist_item.state != UpdateState.UPDATED:
                 continue
-            unzip_dirpath = item.unzip_dirpath
+            unzip_dirpath = dist_item.unzip_dirpath
             if unzip_dirpath and os.path.exists(unzip_dirpath):
                 output.append(unzip_dirpath)
+
+        dependency_dist_item = self.get_dependency_dist_item()
+        if dependency_dist_item is not None:
+            dependencies_dir = None
+            unzip_dirpath = dependency_dist_item.unzip_dirpath
+            if unzip_dirpath:
+                dependencies_dir = os.path.join(unzip_dirpath, "dependencies")
+
+            if dependencies_dir and os.path.exists(dependencies_dir):
+                output.append(dependencies_dir)
         return output
 
 

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1609,14 +1609,14 @@ class AyonDistribution:
             and dependency_dist_item.need_distribution
             and dependency_dist_item.state == UpdateState.UPDATED
         ):
-            package = self.dependency_package
+            package = self.dependency_package_item
             source = dependency_dist_item.used_source
             if source is not None:
                 data = {
                     "source": source,
                     "checksum": dependency_dist_item.checksum,
                     "checksum_algorithm": (
-                        dependency_dist_item.checksum_alhorithm),
+                        dependency_dist_item.checksum_algorithm),
                     "distributed_dt": stored_time
                 }
                 self.update_dependency_metadata(package.name, data)

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1403,15 +1403,15 @@ class AyonDistribution:
 
             dist_item = DistributionItem(
                 addon_dest,
-                addon_dest,
-                state,
-                addon_version_item.checksum,
-                addon_version_item.checksum_algorithm,
-                self._dist_factory,
-                list(addon_version_item.sources),
-                downloader_data,
-                full_name,
-                self.log
+                download_dirpath=addon_dest,
+                state=state,
+                checksum=addon_version_item.checksum,
+                checksum_algorithm=addon_version_item.checksum_algorithm,
+                factory=self._dist_factory,
+                sources=list(addon_version_item.sources),
+                downloader_data=downloader_data,
+                item_label=full_name,
+                logger=self.log
             )
             output.append({
                 "dist_item": dist_item,
@@ -1445,14 +1445,15 @@ class AyonDistribution:
 
         return DistributionItem(
             zip_dir,
-            package_dir,
-            state,
-            package.checksum,
-            self._dist_factory,
-            package.sources,
-            downloader_data,
-            package.name,
-            self.log,
+            download_dirpath=package_dir,
+            state=state,
+            checksum=package.checksum,
+            checksum_algorithm=package.checksum_algorithm,
+            factory=self._dist_factory,
+            sources=package.sources,
+            downloader_data=downloader_data,
+            item_label=os.path.splitext(package.filename)[0],
+            logger=self.log,
         )
 
     def get_addon_dist_items(self):

--- a/common/ayon_common/distribution/data_structures.py
+++ b/common/ayon_common/distribution/data_structures.py
@@ -1,3 +1,4 @@
+import os
 import attr
 from enum import Enum
 
@@ -191,7 +192,7 @@ class AddonInfo(object):
 @attr.s
 class DependencyItem(object):
     """Object matching payload from Server about single dependency package"""
-    name = attr.ib()
+    filename = attr.ib()
     platform_name = attr.ib()
     checksum = attr.ib()
     checksum_algorithm = attr.ib(default=None)
@@ -202,15 +203,16 @@ class DependencyItem(object):
 
     @classmethod
     def from_dict(cls, package):
+        filename = package["filename"]
         src_sources = package.get("sources") or []
         for source in src_sources:
             if source.get("type") == "server" and not source.get("filename"):
-                source["filename"] = package["filename"]
+                source["filename"] = filename
 
-        sources, unknown_sources = prepare_sources(package.get("sources"))
+        sources, unknown_sources = prepare_sources(src_sources)
 
         return cls(
-            name=package["filename"],
+            filename=filename,
             platform_name=package["platform"],
             sources=sources,
             unknown_sources=unknown_sources,

--- a/start.py
+++ b/start.py
@@ -362,10 +362,14 @@ def _check_and_update_from_ayon_server():
         if path
     ]
 
-    for path in distribution.get_sys_paths():
+    for path in distribution.get_python_paths():
         sys.path.insert(0, path)
         if path not in python_paths:
             python_paths.append(path)
+
+    for path in distribution.get_sys_paths():
+        sys.path.insert(0, path)
+
     os.environ["PYTHONPATH"] = os.pathsep.join(python_paths)
 
 

--- a/start.py
+++ b/start.py
@@ -382,7 +382,30 @@ def boot():
 
 
 def main_cli():
+    """Main startup logic.
+
+    This is the main entry point for the AYON launcher. At this
+    moment is fully dependent on 'openpype' addon. Which means it
+    contains more logic than it should.
+    """
+
     from openpype import cli
+    from openpype import PACKAGE_DIR
+
+    python_path = os.getenv("PYTHONPATH", "")
+    split_paths = python_path.split(os.pathsep)
+
+    additional_paths = [
+        # add OpenPype tools
+        os.path.join(PACKAGE_DIR, "tools"),
+        # add common OpenPype vendor
+        # (common for multiple Python interpreter versions)
+        os.path.join(PACKAGE_DIR, "vendor", "python", "common")
+    ]
+    for path in additional_paths:
+        split_paths.insert(0, path)
+        sys.path.insert(0, path)
+    os.environ["PYTHONPATH"] = os.pathsep.join(split_paths)
 
     _print(">>> loading environments ...")
     _print("  - global AYON ...")

--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -580,7 +580,8 @@ def store_installer_metadata(build_root, installer_path):
         "checksum": file_hash,
         "checksum_algorithm": "md5",
         "size": os.path.getsize(installer_path),
-        "installer_path": installer_path
+        "installer_path": installer_path,
+        "filename": os.path.basename(installer_path),
     })
     store_build_metadata(build_root, metadata)
 
@@ -592,7 +593,9 @@ def create_installer(ayon_root, build_root):
 
     installer_path = _create_installer(
         ayon_root, build_root, build_content_root, ayon_version)
-    store_installer_metadata(build_root, str(installer_path))
+    store_installer_metadata(
+        build_root, str(installer_path.absolute())
+    )
 
 
 def main():


### PR DESCRIPTION
## Changelog Description
Finalized distribution of dependency packages once we have one ready.

## Additional info
Fixed DistributionItem creation for dependency package item. Renamed `name` to `filename` in dependency package item. Fixed OpenPype addon initialization in `main_cli` so vendorized modules are added to python and sys path. Build metadata file contains `"filename"`.

## Testing notes:
Prerequirements:
- Running AYON server 0.3.x
- Having at least `openpype` and `core` addons available

1. Build ayon-launcher
2. Upload installer to server
3. Create bundle with requested addons and new installer
4. Create dependency package for the bundle (using `ayon-dependencies-tool`)
5. Launch ayon-launcher
6. Validate it work

Note:
To make it fully work also add `ayon_third_party` and `ayon_ocio` addons and addons of your hosts for settings.