### PR TITLE
Build: Make sure requirements.txt have utf-8 encoding

### DIFF
--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -273,7 +273,8 @@ function Build-Ayon($MakeInstaller = $false) {
     Write-Color -Text ">>> ", "Building AYON ..." -Color Green, White
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
-    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze > "$($repo_root)\build\requirements.txt"
+    # Make sure output is utf-8
+    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze | Out-File -Encoding UTF8 "$($repo_root)\build\requirements.txt"
     $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
     if ($LASTEXITCODE -ne 0)


### PR DESCRIPTION
## Changelog Description
Requirements file created during build has utf-8 encoding instead of utf-16.

## Additional info
When had utf-16 encoding 2 first bytes of file are markings of the utf-16 which caused crashes on file parsing.
