### PR TITLE
MacOS build fix

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -264,9 +264,6 @@ build_ayon () {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     macoscontents="$repo_root/build/AYON $ayon_version.app/Contents"
     macosdir="$macoscontents/MacOS"
-    # fix cx_Freeze libs issue
-    echo -e "${BIGreen}>>>${RST} Fixing libs ..."
-    mv "$macosdir/dependencies/cx_Freeze" "$macosdir/lib/"  || { echo -e "${BIRed}!!!>${RST} ${BIYellow}Can't move cx_Freeze libs${RST}"; return 1; }
 
     # force hide icon from Dock
     defaults write "$macoscontents/Info" LSUIElement 1


### PR DESCRIPTION
## Changelog Description
Ayon-launcher can be built on macOS.

## Additional info
Remove cx_Freeze from dependencies directory which will keep cx_Freeze output lib. That works for all platforms because cx_Freeze is dependency that should not be propagated to any other process.

## Testing notes:
1. Build AYON on macOS
2. Run built application
