### PR TITLE
Start: Add common path to PYTHONPATH

### DIFF
--- a/start.py
+++ b/start.py
@@ -124,7 +124,7 @@ common_path = os.path.join(AYON_ROOT, "common")
 sys.path.insert(0, common_path)
 if common_path in _python_paths:
     _python_paths.remove(common_path)
-_python_paths.insert(0, _dependencies_path)
+_python_paths.insert(0, common_path)
 
 # Vendored python modules that must not be in PYTHONPATH environment but
 #   are required for OpenPype processes


### PR DESCRIPTION
## Changelog Description
Add `ayon_common` to PYTHONPATH properly.

## Additional info
There was a bug, wrong variables was used to add common to python path resulting in having dependencies path in PYTHONPATH twice and not having common there at all.
