### PR TITLE
Make installer script modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,21 @@ pyenv local 3.9.6
 4) Run `./tools/make.sh make-installer` to create an installer file in `./build/`.
 
 
+Make installer
+----------------
+Installer is expected result for AYON server. The output is located in `./build/installer/` directory. You should find there a json file and installer file. Json is minimum requirement for AYON server to be able to use installer version in release bundle. It is recommended to put installer to server too for automated updates.
+
+### Windows
+Run `./tools/manage.ps1 create-server-package`
+
+### Linux & macOS
+Run `./tools/make.sh create-server-package`
+
+
 Upload installer to server
 ----------------
 
-Installer must be available on a server to be able to set it in release bundle and to be downloaded by users.
+Create installer information from json file on server and upload the installer file to be downloaded by users.
 
 ### Windows
 Run `./tools/manage.ps1 upload --server <your server> --api-key <your api key>`

--- a/README.md
+++ b/README.md
@@ -224,18 +224,6 @@ Run `./tools/make.sh upload --server <your server> --api-key <your api key>`
 Upload command has more options, run `./tools/manage.ps1 upload --help` or `./tools/make.sh upload --help` to see them. For example, it is posssible to use username & password instead of api key.
 
 
-Create package for AYON server
-----------------
-Create a package with metadata information for AYON server. This package can be re-used on multiple servers.
-NOTE: Option to upload installer using this package is not implemented on server side, yet.
-
-### Windows
-Run `./tools/manage.ps1 create-server-package`
-
-### Linux & macOS
-Run `./tools/make.sh create-server-package`
-
-
 Running AYON Desktop application
 ----------------
 

--- a/tools/installer_post_process.py
+++ b/tools/installer_post_process.py
@@ -13,7 +13,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_installer_dir():
-    return Path(CURRENT_DIR).parent / "installer"
+    return Path(CURRENT_DIR).parent / "build"/ "installer"
 
 
 class ZipFileLongPaths(zipfile.ZipFile):
@@ -87,10 +87,10 @@ def find_installer_info(installer_dir: Optional[str]) -> InstallerInfo:
     filename = metadata.get("filename")
     if not filename:
         raise click.BadParameter(
-            " is not available. Run 'make-installer' first."
+            "Metadata file does not contain information about installer name."
         )
 
-    installer_path = metadata_path / filename
+    installer_path = installer_dir / filename
     if not installer_path.exists():
         raise click.BadParameter(
             "Installer is not available. Run 'make-installer' first."
@@ -232,7 +232,6 @@ def cli():
     help="Password (Only if api key is not provided)")
 @click.option(
     "--installer-dir",
-    store_key="installer_dir",
     default=None,
     help="Directory where installer with metadata is located")
 @click.option(
@@ -265,7 +264,6 @@ def upload(server, api_key, username, password, installer_dir, force):
     help="Password (Only if api key is not provided)")
 @click.option(
     "--installer-dir",
-    store_key="installer_dir",
     default=None,
     help="Directory where installer with metadata is located")
 @click.option(

--- a/tools/installer_post_process.py
+++ b/tools/installer_post_process.py
@@ -255,38 +255,6 @@ def create_server_installer(
     create_installer(api, installer_info, force)
 
 
-@cli.command(help="Upload installer to AYON server")
-@click.option(
-    "-o", "--output",
-    help="Output directory")
-@click.option(
-    "-f", "--filename",
-    help="Output filename (must have .zip extension)")
-def create_server_package(
-    output: Union[str, None], filename: Union[str, None]
-):
-    """Create a zip file with the installer and metadata ready for server."""
-
-    installer_info: InstallerInfo = find_installer_info()
-    if not filename:
-        filename = (
-            "ayon-server-installer"
-            f"-{installer_info.platform}-{installer_info.version}.zip"
-        )
-
-    if output is None:
-        output = os.path.dirname(installer_info.installer_path)
-
-    output_path: str = os.path.join(output, filename)
-    metadata: dict[str, Any] = asdict(installer_info)
-    metadata.pop("installer_path")
-    with ZipFileLongPaths(output_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
-        zip_file.writestr(
-            f"{installer_info.filename}.json", json.dumps(metadata)
-        )
-        zip_file.write(installer_info.installer_path, installer_info.filename)
-
-
 def main():
     cli(obj={}, prog_name="AYON-uploader")
 

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -359,10 +359,6 @@ main() {
       installer_post_process upload "${@:2}" || return_code=$?
       exit $return_code
       ;;
-    "createserverpackage")
-      installer_post_process create-server-package "${@:2}" || return_code=$?
-      exit $return_code
-      ;;
     "run")
       run_from_code "${@:2}" || return_code=$?
       exit $return_code

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -180,7 +180,6 @@ function Default-Func {
     Write-Host "  make-installer                Make desktop application installer"
     Write-Host "  build-make-installer          Build desktop application and make installer"
     Write-Host "  upload                        Upload installer to server"
-    Write-Host "  create-server-package         Create package ready for AYON server"
     Write-Host "  run                           Run desktop application from code"
     Write-Host ""
 }
@@ -371,9 +370,6 @@ function Main {
     } elseif ($FunctionName -eq "upload") {
         Change-Cwd
         Installer-Post-Process "upload" @arguments
-    } elseif ($FunctionName -eq "createserverpackage") {
-        Change-Cwd
-        Installer-Post-Process "create-server-package" @arguments
     } else {
         Write-Host "Unknown function ""$FunctionName"""
         Default-Func


### PR DESCRIPTION
## Changelog Description
Modified make installer to create installer in subdir `build/installer/` which will contain installer file and metadata json ready for AYON server. Removed `create-server-package` command which does not have real usage for deployment.

## Testing notes:
Everything should work as before this PR.
1. Run `build` command
2. Run `make-installer` command
3. Run `upload` command

The only difference is that installer is nested subfolder `./build/installer/`.