### PR TITLE
Windows: Install directory fill fix

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -118,15 +118,19 @@ begin
   if Length(NewInstallFolder) = 0 then
   begin
     NewInstallRoot := GetParameter('INSTALLROOT');
-    if Length(NewInstallFolder) = 0 then
-      NewInstallRoot := NewInstallRoot + '\{#MyAppName} {#AppVer}'
+    if Length(NewInstallRoot) > 0 then
+    begin
+      NewInstallFolder := NewInstallRoot + '\{#MyAppName} {#AppVer}'
+    end
     else
+    begin
       CurrentDefaultDir := ExpandConstant('{autopf64}');
       ProgramFilesDir := ExpandConstant('{commonpf64}');
       if CompareStr(CurrentDefaultDir, ProgramFilesDir) = 0 then
         NewInstallFolder := ExpandConstant('{commonpf64}') + '\Ynput\{#MyAppName} {#AppVer}'
       else
         NewInstallFolder := ExpandConstant('{localappdata}') + '\Ynput\AYON\app\{#MyAppName} {#AppVer}';
+    end;
   end;
   WizardForm.DirEdit.Text := NewInstallFolder;
 end;

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -118,19 +118,16 @@ begin
   if Length(NewInstallFolder) = 0 then
   begin
     NewInstallRoot := GetParameter('INSTALLROOT');
-    if Length(NewInstallRoot) > 0 then
-    begin
-      NewInstallFolder := NewInstallRoot + '\{#MyAppName} {#AppVer}'
-    end
-    else
+    if Length(NewInstallRoot) = 0 then
     begin
       CurrentDefaultDir := ExpandConstant('{autopf64}');
       ProgramFilesDir := ExpandConstant('{commonpf64}');
       if CompareStr(CurrentDefaultDir, ProgramFilesDir) = 0 then
-        NewInstallFolder := ExpandConstant('{commonpf64}') + '\Ynput\{#MyAppName} {#AppVer}'
+        NewInstallRoot := ExpandConstant('{commonpf64}') + '\Ynput'
       else
-        NewInstallFolder := ExpandConstant('{localappdata}') + '\Ynput\AYON\app\{#MyAppName} {#AppVer}';
+        NewInstallRoot := ExpandConstant('{localappdata}') + '\Ynput\AYON\app';
     end;
+    NewInstallFolder := NewInstallRoot + '\{#MyAppName} {#AppVer}';
   end;
   WizardForm.DirEdit.Text := NewInstallFolder;
 end;


### PR DESCRIPTION
## Changelog Description
Path where application is installed should be filled correctly. Fix `/INSTALLDIR=...` logic.

## Additional info
The path always ended in local app data because it was the last option in code block (some Pascal condition logic).

## Testing notes:
1. Make installer
2. Run installer and choose to install for ALL USERS
   - [ ] Path to Program files should be prefilled
3. Run installer and choose to install only locally
   - [ ] Path to Local app data should be prefilled
4. Run installer through command line and add custom install root `<installer path> /INSTALLROOt="C:\my custom\path"`
   - [ ] Path to `C:\my custom\path\AYON <version>` should be prefilled