### PR TITLE
Use correct AYON version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,12 @@ from cx_Freeze import setup, Executable
 ayon_root = Path(os.path.dirname(__file__))
 resources_dir = ayon_root / "common" /  "ayon_common" / "resources"
 
-version = {}
+version_content = {}
 
 with open(ayon_root / "version.py") as fp:
-    exec(fp.read(), version)
+    exec(fp.read(), version_content)
 
-version_match = re.search(r"(\d+\.\d+.\d+).*", version["__version__"])
-__version__ = version_match.group(1)
+__version__ = version_content["__version__"]
 
 low_platform_name = platform.system().lower()
 IS_WINDOWS = low_platform_name == "windows"

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -227,7 +227,7 @@ build_ayon () {
   # Directories
   pushd "$repo_root" > /dev/null || return > /dev/null
 
-  version_command="import os;import re;version={};exec(open(os.path.join('$repo_root', 'version.py')).read(), version);print(re.search(r'(\d+\.\d+.\d+).*', version['__version__'])[1]);"
+  version_command="import os;import re;version={};exec(open(os.path.join('$repo_root', 'version.py')).read(), version);print(version['__version__']);"
   ayon_version="$(python <<< ${version_command})"
 
   echo -e "${BIYellow}---${RST} Cleaning build directory ..."

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -95,9 +95,7 @@ function Show-PSWarning() {
 }
 
 function Get-Ayon-Version() {
-    $version_file = Get-Content -Path "$($repo_root)\version.py"
-    $result = [regex]::Matches($version_file, '__version__ = "(?<version>\d+\.\d+.\d+.*)"')
-    $ayon_version = $result[0].Groups['version'].Value
+    $ayon_version = Invoke-Expression -Command "python -c ""import os;import sys;content={};f=open(r'$($repo_root)\version.py');exec(f.read(),content);f.close();print(content['__version__'])"""
     if (-not $ayon_version) {
       Write-Color -Text "!!! ", "Cannot determine AYON version." -Color Yellow, Gray
       return $null
@@ -167,8 +165,10 @@ print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))
 }
 
 function Default-Func {
+    $ayon_version = Get-Ayon-Version
     Write-Host ""
     Write-Host "Ayon desktop application tool"
+    Write-Host "    version $($ayon_version)"
     Write-Host ""
     Write-Host "Usage: ./manage.ps1 [target]"
     Write-Host ""
@@ -252,7 +252,7 @@ function Build-Ayon($MakeInstaller = $false) {
     } else {
         Write-Color -Text "*** ", "Not updating submodules ..." -Color Green, Gray
     }
-
+    $ayon_version = Get-Ayon-Version
     Write-Color -Text ">>> ", "AYON [ ", $ayon_version, " ]" -Color Green, White, Cyan, White
 
     Write-Color -Text ">>> ", "Reading Poetry ... " -Color Green, Gray -NoNewline


### PR DESCRIPTION
## Changelog Description
MacOs build expected wrong version name in output filename because did not expect semver in version.py.

## Additional information
Added same approach how version is received to manage.ps1.

## Testing notes:
Build on macOs should work again.
