### PR TITLE
Executable version lookup fix

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -347,7 +347,7 @@ def cleanup_executables_info():
 
     new_executables_info = []
     changed = False
-    for item in get_executables_info():
+    for item in get_executables_info(check_cleanup=False):
         executable = item.get("executable")
         if not executable or not os.path.exists(executable):
             changed = True

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -289,22 +289,36 @@ def store_current_executable_info():
     store_executables([sys.executable])
 
 
-def get_executables_info_by_version(version):
+def get_executables_info_by_version(version, validate=True):
     """Get available executable info by version.
 
     Args:
         version (str): Version of executable.
+        validate (bool): Validate if 'version.py' contains same version.
 
     Returns:
         list[dict[str, Any]]: Executable info matching version.
     """
 
     executables_info = get_executables_info()
-    return [
-        item
-        for item in executables_info.get("available_versions", [])
-        if item.get("version") == version
-    ]
+    available_versions = executables_info.get("available_versions", [])
+    if not validate or not available_versions:
+        return [
+            item
+            for item in available_versions
+            if item.get("version") == version
+        ]
+
+    output = []
+    for item in available_versions:
+        executable = item.get("executable")
+        if not executable or not os.path.exists(executable):
+            continue
+
+        executable_version = load_executable_version(executable)
+        if executable_version == version:
+            output.append(item)
+    return output
 
 
 def get_executable_paths_by_version(version, only_available=True):

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -320,7 +320,7 @@ def cleanup_executables_info():
         new_executables_info.append(item)
 
     if changed:
-        store_executables_info(new_executables_info)
+        store_executables(new_executables_info)
 
 
 class _Cache:


### PR DESCRIPTION
## Changelog Description
Fixed issues with lookup for version of AYON launcher.

## Additional info
Stored launcher versions are validated once in 2 days. The validation happens automatically on launch. When existing version of AYON launcher is found out, the launcher must contain `version.py` with correct version -> in other word version in metadata has no value for automated lookup of AYON launcher versions. Cleanup function was fixed to work as expected.

The issue was that if anyone would start ayon from the same location and the launched version would not be demanded version by server, and the demanded version would point to the same executable, it would cause infinite start of ayon processes.

## Testing notes:
Hard to tell how to test. `%\Ynput\AYON\executables.json` should contain less informarmation if there was before more of them.
