### PR TITLE
Use AYON launcher in docstrings

### DIFF
--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -1,11 +1,11 @@
-"""Handle credentials and connection to server for client application.
+"""Handle credentials and connection to server for AYON launcher.
 
 Cache and store used server urls. Store/load API keys to/from keyring if
 needed. Store metadata about used urls, usernames for the urls and when was
 the connection with the username established.
 
 On bootstrap is created global connection with information about site and
-client version. The connection object lives in 'ayon_api'.
+AYON launcher version. The connection object lives in 'ayon_api'.
 """
 
 import os
@@ -449,10 +449,10 @@ def set_environments(url: str, token: str):
 
 
 def create_global_connection():
-    """Create global connection with site id and client version.
+    """Create global connection with site id and AYON launcher version.
 
     Make sure the global connection in 'ayon_api' have entered site id and
-    client version.
+    AYON launcher version.
 
     Set default settings variant to use based on 'is_staging_enabled'.
     """

--- a/common/ayon_common/distribution/README.md
+++ b/common/ayon_common/distribution/README.md
@@ -8,7 +8,7 @@ Each host, module will be separate Addon in the future. Each v4 server could run
 Client (running on artist machine) will in the first step ask v4 for list of enabled addons.
 (It expects list of json documents matching to `addon_distribution.py:AddonInfo` object.)
 Next it will compare presence of enabled addon version in local folder. In the case of missing version of
-an addon, client will use information in the addon to download (from http/shared local disk/git) zip file
+an addon, AYON launcher will use information in the addon to download (from http/shared local disk/git) zip file
 and unzip it.
 
 Required part of addon distribution will be sharing of dependencies (python libraries, utilities) which is not part of this folder.

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -20,7 +20,7 @@ IMPLEMENTED_ARCHIVE_FORMATS = {
 
 
 def get_ayon_appdirs(*args):
-    """Local app data directory of AYON client.
+    """Local app data directory of AYON launcher.
 
     Args:
         *args (Iterable[str]): Subdirectories/files in local app data dir.


### PR DESCRIPTION
## Changelog Description
Use AYON launcher instead of AYON client in documentation.