### PR TITLE
Encoding issues during build

### DIFF
--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -375,7 +375,7 @@ def get_packages_info(build_root):
             "Failed to get packages info -> couldn't find 'requirements.txt'."
         )
 
-    with open(str(requirements_path), "r") as stream:
+    with open(str(requirements_path), "r", encoding="utf-8") as stream:
         content = stream.read()
 
     packages = {}

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -274,7 +274,7 @@ function Build-Ayon($MakeInstaller = $false) {
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
     # Make sure output is utf-8
-    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze | Out-File -Encoding UTF8 "$($repo_root)\build\requirements.txt"
+    & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze | Out-File -Encoding UTF8NoBOM "$($repo_root)\build\requirements.txt"
     $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
     if ($LASTEXITCODE -ne 0)


### PR DESCRIPTION
## Changelog Description
Force to use utf-8 encoding when handling requirements.

## Additional info
This resolves issues when requirements file started with BOM (I couldn't replicate it).
