### PR TITLE
Change output filename of macOs installer

### DIFF
--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -535,7 +535,7 @@ def _create_darwin_installer(
     """
 
     app_filepath = _get_darwin_output_path(build_root, ayon_version)
-    output_path = installer_root / f"AYON-{ayon_version}-Installer.dmg"
+    output_path = installer_root / f"AYON-{ayon_version}-macos.dmg"
     # TODO check if 'create-dmg' is available
     try:
         subprocess.call(["create-dmg"])


### PR DESCRIPTION
## Changelog Description
Change filename of created installer for macOs. Instead of `AYON-{version}-Installer.dmg` it is `AYON-{version}-macos.dmg`.

## Testing notes:
1. Try to build and make installer on MacOS
2. Ouptut installer should be named `AYON-{version}.macos.dmg`
