### PR TITLE
Docker build: CentOS build fixes

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -33,12 +33,16 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         wget \
         gcc \
         zlib-devel \
+        pcre-devel \
+        perl-core \
         bzip2 \
         bzip2-devel \
         readline-devel \
         sqlite sqlite-devel \
         openssl-devel \
         openssl-libs \
+        openssl11-devel \
+        openssl11-libs \
         tk-devel libffi-devel \
         patchelf \
         automake \
@@ -69,7 +73,13 @@ RUN echo 'export PATH="$HOME/.pyenv/bin:$PATH"'>> $HOME/.bashrc \
     && echo 'eval "$(pyenv init -)"' >> $HOME/.bashrc \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> $HOME/.bashrc \
     && echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
-RUN source $HOME/.bashrc && pyenv install ${PYTHON_VERSION}
+
+RUN source $HOME/.bashrc \
+    && export CPPFLAGS="-I/usr/include/openssl11" \
+    && export LDFLAGS="-L/usr/lib64/openssl11 -lssl -lcrypto" \
+    && export PATH=/usr/local/openssl/bin:$PATH \
+    && export LD_LIBRARY_PATH=/usr/local/openssl/lib:$LD_LIBRARY_PATH \
+    && pyenv install ${PYTHON_VERSION}
 
 COPY . /opt/ayon-launcher/
 RUN rm -rf /opt/ayon-launcher/.poetry || echo "No Poetry installed yet."
@@ -88,7 +98,7 @@ RUN source $HOME/.bashrc \
     && ./tools/make.sh build-make-installer
 
 RUN cp /usr/lib64/libffi* ./build/output/lib \
-    && cp /usr/lib64/libssl* ./build/output/lib \
-    && cp /usr/lib64/libcrypto* ./build/output/lib \
+    && cp /usr/lib64/openssl11/libssl* ./build/output/lib \
+    && cp /usr/lib64/openssl11/libcrypto* ./build/output/lib \
     && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/output/lib \
     && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide2/Qt/lib

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -87,8 +87,8 @@ RUN source $HOME/.bashrc \
     && ./tools/make.sh install-runtime \
     && ./tools/make.sh build-make-installer
 
-RUN cp /usr/lib64/libffi* ./build/exe.linux-x86_64-3.9/lib \
-    && cp /usr/lib64/libssl* ./build/exe.linux-x86_64-3.9/lib \
-    && cp /usr/lib64/libcrypto* ./build/exe.linux-x86_64-3.9/lib \
-    && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/exe.linux-x86_64-3.9/lib \
-    && cp /usr/lib64/libxcb* ./build/exe.linux-x86_64-3.9/vendor/python/PySide2/Qt/lib
+RUN cp /usr/lib64/libffi* ./build/output/lib \
+    && cp /usr/lib64/libssl* ./build/output/lib \
+    && cp /usr/lib64/libcrypto* ./build/output/lib \
+    && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/output/lib \
+    && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide2/Qt/lib

--- a/poetry.lock
+++ b/poetry.lock
@@ -2244,14 +2244,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ aiohttp = "^3.7"
 acre = { git = "https://github.com/pypeclub/acre.git" }
 appdirs = { git = "https://github.com/ActiveState/appdirs.git", branch = "master" }
 blessed = "^1.17" # terminal formatting
+urllib3 = "1.26.16"
 coolname = "*"
 Click = "^8"
 dnspython = "^2.1.0"

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -139,6 +139,16 @@ install_poetry () {
   export POETRY_HOME="$repo_root/.poetry"
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -sSL https://install.python-poetry.org/ | python -
+
+  # Force poetry to use older urllib3 if OpenSSL has version < 1.1.1
+  local ssl_command
+  ssl_command="import ssl;print(1 if ssl.OPENSSL_VERSION_INFO < (1, 1, 1) else 0)"
+  local downgrade_urllib
+  downgrade_urllib="$("$POETRY_HOME/venv/bin/python" <<< ${ssl_command})"
+  if [ $downgrade_urllib -eq "1" ]; then
+    echo -e "${BIGreen}>>>${RST} Installing older urllib3 ..."
+    "$POETRY_HOME/venv/bin/python" -m pip install urllib3==1.26.16
+  fi
 }
 
 ##############################################################################
@@ -169,16 +179,6 @@ create_env () {
   else
     echo -e "${BIYellow}NOT FOUND${RST}"
     install_poetry || { echo -e "${BIRed}!!!${RST} Poetry installation failed"; return 1; }
-  fi
-
-  # Force poetry to use older urllib3 if OpenSSL has version < 1.1.1
-  local ssl_command
-  ssl_command="import ssl;print(1 if ssl.OPENSSL_VERSION_INFO < (1, 1, 1) else 0)"
-  local downgrade_urllib
-  downgrade_urllib="$("$POETRY_HOME/venv/bin/python" <<< ${ssl_command})"
-  if [ $downgrade_urllib -eq "1" ]; then
-    echo -e "${BIGreen}>>>${RST} Installing older urllib3 ..."
-    "$POETRY_HOME/venv/bin/python" -m pip install urllib3==1.26.16
   fi
 
   if [ -f "$repo_root/poetry.lock" ]; then

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -171,6 +171,16 @@ create_env () {
     install_poetry || { echo -e "${BIRed}!!!${RST} Poetry installation failed"; return 1; }
   fi
 
+  # Force poetry to use older urllib3 if OpenSSL has version < 1.1.1
+  local ssl_command
+  ssl_command="import ssl;print(1 if ssl.OPENSSL_VERSION_INFO < (1, 1, 1) else 0)"
+  local downgrade_urllib
+  downgrade_urllib="$("$POETRY_HOME/venv/bin/python" <<< ${ssl_command})"
+  if [ $downgrade_urllib -eq "1" ]; then
+    echo -e "${BIGreen}>>>${RST} Installing older urllib3 ..."
+    "$POETRY_HOME/venv/bin/python" -m pip install urllib3==1.26.16
+  fi
+
   if [ -f "$repo_root/poetry.lock" ]; then
     echo -e "${BIGreen}>>>${RST} Updating dependencies ..."
   else


### PR DESCRIPTION
## Changelog Description
Fixed copy of output from CentOS. Force poetry to lower `urllib3` version if OpenSSL version is lower than 1.1.1.

Define `urllib3` version that supports older OpenSSL in pyproject.toml. That is because most of DCCs are build with older ssl (e.g. Maya 2022, Nuke 13).

## Testing notes:
1. Run `./tools/make.sh docker-build centos7` (or `./tools/manage.ps1 docker-build centos7` for windows)
2. Check output
