### PR TITLE
Centos build: Create symlinks for ssl libs

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -100,5 +100,7 @@ RUN source $HOME/.bashrc \
 RUN cp /usr/lib64/libffi* ./build/output/lib \
     && cp /usr/lib64/openssl11/libssl* ./build/output/lib \
     && cp /usr/lib64/openssl11/libcrypto* ./build/output/lib \
+    && ln -sr ./build/output/lib/libssl.so ./build/output/lib/libssl.1.1.so \
+    && ln -sr ./build/output/lib/libcrypto.so ./build/output/lib/libcrypto.1.1.so \
     && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/output/lib \
     && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide2/Qt/lib


### PR DESCRIPTION
## Changelog Description
Docker build was missing `libssl.1.1.so` and `libcrypto.1.1.so` symlinks needed by the executable itself, because Python is now explicitly built with OpenSSL 1.1.1. This is similar to ynput/OpenPype#5633

## Additional info
This just creating symlinks, but to already copied libraries, but it should be probably handled more gracefuly.

## Testing notes:
- Build Centos 7 variant
- Run it on vanilla Centos 7 system