### PR TITLE
Add login argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ There are reserver global arguments that cannot be used in any cli handling:
 - `--use-dev` - Use dev bundle and settings, if bundle is not explicitly defined.
 - `--use-staging` - Use staging settings, and use staging bundle, if bundle is not explicitly defined. Cannot be combined with staging.
 - `--headless` - Tell AYON to run in headless mode. No UIs are shown during bootstrap. Affects `AYON_HEADLESS_MODE` environment variable. Custom logic must handle headless mode on own.
+- `--ayon-login` - Show login dialog on startup.
 - `--skip-bootstrap` - Skip bootstrap process. Used for inner logic of distribution.
 
 ### Environment variables

--- a/start.py
+++ b/start.py
@@ -171,6 +171,11 @@ if "--use-dev" in sys.argv:
     sys.argv.remove("--use-dev")
     os.environ["AYON_USE_DEV"] = "1"
 
+SHOW_LOGIN_UI = False
+if "--ayon-login" in sys.argv:
+    sys.argv.remove("--ayon-login")
+    SHOW_LOGIN_UI = True
+
 if "--headless" in sys.argv:
     os.environ["AYON_HEADLESS_MODE"] = "1"
     os.environ["OPENPYPE_HEADLESS_MODE"] = "1"
@@ -355,9 +360,27 @@ def set_addons_environments():
         os.environ.update(env)
 
 
-def _connect_to_ayon_server():
+def _connect_to_ayon_server(force=False):
+    """Connect to AYON server.
+
+    Load existing credentials to AYON server, and show login dialog if are not
+        valid. When 'force' is set to 'True' then login dialog is always
+        shown.
+
+    Login dialog cannot be shown in headless mode. In that case program
+        is terminated with.
+    If user closed dialog, program is terminated with exit code 0.
+
+    Args:
+        force (Optional[bool]): Force login to server.
+    """
+
     load_environments()
-    if not need_server_or_login():
+    need_login = True
+    if not force:
+        need_login = need_server_or_login()
+
+    if not need_login:
         return
 
     if HEADLESS_MODE_ENABLED:
@@ -806,6 +829,9 @@ def get_info(use_staging=None, use_dev=None) -> list:
 
 
 def main():
+    if SHOW_LOGIN_UI:
+        _connect_to_ayon_server(True)
+
     if SKIP_BOOTSTRAP:
         return script_cli()
 

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -423,6 +423,7 @@ function Main {
     }
     $FunctionName = $FunctionName.ToLower() -replace "\W"
     if ($FunctionName -eq "run") {
+        Change-Cwd
         Run-From-Code
     } elseif ($FunctionName -eq "createenv") {
         Change-Cwd


### PR DESCRIPTION
## Changelog Description
It is possible to show login on start of launcher.

## Additional info
Added `--ayon-login` argument flag which can trigger to show login dialog to change login before bootstrap.

## Testing notes:
1. Start ayon with `--ayon-login` argument
2. A login dialog should show asking to login
