### PR TITLE
Set env variable for settings variant

### DIFF
--- a/start.py
+++ b/start.py
@@ -290,6 +290,13 @@ from ayon_api import (
     get_addons_studio_settings,
 )
 from ayon_api.constants import SERVER_URL_ENV_KEY, SERVER_API_ENV_KEY
+# Kept for backwards compatibility of older ayon-python-api in case older
+#     is used.
+try:
+    from ayon_api.constants import DEFAULT_VARIANT_ENV_KEY
+except ImportError:
+    DEFAULT_VARIANT_ENV_KEY = "AYON_DEFAULT_SETTINGS_VARIANT"
+
 from ayon_common import is_staging_enabled, is_dev_mode_enabled
 from ayon_common.connection.credentials import (
     ask_to_login_ui,
@@ -422,6 +429,7 @@ def _set_default_settings_variant(use_dev, use_staging, bundle_name):
     else:
         variant = "production"
 
+    os.environ[DEFAULT_VARIANT_ENV_KEY] = variant
     # Make sure dev env variable is set/unset for cases when dev mode is not
     #   enabled by '--use-dev' but by bundle name
     if use_dev:


### PR DESCRIPTION
## Changelog Description
Set environment variable to define default settings variant.

## Additional info
The value can be used in non-ayon-launcher processes to define default variant without worrying when it should be set up (helpful in core > openpype addon).

Note: Core/openpype addon is handling that now by making sure a specific method in openpype.client.server is always called which may be dangerous in future. It is possible to use `ayon_api` before calling the function which may lead to incosistency. https://github.com/ynput/OpenPype/blob/develop/openpype/client/server/utils.py#L13 

This PR is based on update to ayon-api to 0.5.4 https://github.com/ynput/ayon-launcher/pull/72
