### PR TITLE
Platform name is not passed to 'download_dependency_package'

### DIFF
--- a/common/ayon_common/distribution/downloaders.py
+++ b/common/ayon_common/distribution/downloaders.py
@@ -166,7 +166,6 @@ class AyonServerDownloader(SourceDownloader):
                 data["name"],
                 destination_dir,
                 filename,
-                platform_name=data["platform"],
                 chunk_size=cls.CHUNK_SIZE,
                 progress=transfer_progress
             )


### PR DESCRIPTION
## Changelog Description
Platform name is not used in `download_dependency_package` since ayon-python-api 0.3.x, and since last release is marked as deprecated.

## Testing notes:
1. Make sure bundle you're going to use have set dependency package.
2. Remove the dependency package from `%LOCALAPPDATA%/Ynput/AYON/dependency_packages/` if you have it downloaded already.
3. Run ayon-launcher with this PR (from code or build)
4. Download of dependency package should start.
5. It should download it just fine.
