### PR TITLE
Runtime dependencies are based on dependency packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -141,7 +141,6 @@ cython_debug/
 
 .poetry/
 .github/
-vendor/bin/
-vendor/python/
+vendor/
 docs/
 website/

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,7 @@ Temporary Items
 /build
 /dist/
 
-/vendor/bin/*
-/vendor/python/*
+/vendor/*
 /.venv
 /venv/
 
@@ -98,4 +97,3 @@ tools/run_eventserver.*
 tools/dev_*
 
 .github_changelog_generator
-

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1933,7 +1933,17 @@ class AyonDistribution:
             List[str]: Paths that should be added to 'sys.path'.
         """
 
-        return []
+        output = []
+        dependency_dist_item = self.get_dependency_dist_item()
+        if dependency_dist_item is not None:
+            runtime_dir = None
+            unzip_dirpath = dependency_dist_item.unzip_dirpath
+            if unzip_dirpath:
+                runtime_dir = os.path.join(unzip_dirpath, "runtime")
+
+            if runtime_dir and os.path.exists(runtime_dir):
+                output.append(runtime_dir)
+        return output
 
     def get_python_paths(self):
         """Get all paths to python packages that should be added to python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,6 @@ version = "6.4.3"
 package = "PySide2"
 version = "5.15.2"
 
-[ayon.runtime.deps]
-# TODO move to ayon_core
-OpenTimelineIO = "0.14.1"
-opencolorio = "2.2.1"
-Pillow = "9.5.0"
-
 [tool.pyright]
 include = [
     "vendor"

--- a/tools/runtime_dependencies.py
+++ b/tools/runtime_dependencies.py
@@ -113,7 +113,12 @@ def install_qtbinding(pyproject, runtime_dep_root, platform_name):
 
 
 def install_runtime_dependencies(pyproject, runtime_dep_root):
-    runtime_deps = pyproject["ayon"]["runtime"]["deps"]
+    runtime_deps = (
+        pyproject
+        .get("ayon", {})
+        .get("runtime", {})
+        .get("deps", {})
+    )
     for package, version in runtime_deps.items():
         _pip_install(runtime_dep_root, package, version)
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,3 +1,0 @@
-### Pype vendor folder
-
-Everything here will be included in frozen code during build but is ignored by git. Useful for binaries like ffmpeg/oiio/etc.


### PR DESCRIPTION
## Changelog Description
Remove dependency packages that should be defined by ayon-core/openpype addon and use runtime dependencies from dependency package.

## Additional info
This PR will be combination of PRs in multiple repositories (OpenPype, ayon-dependencies-tool, ayon-launcher).
- [ayon-launcher](https://github.com/ynput/ayon-launcher/pull/78)
- [ayon-dependencies-tool](https://github.com/ynput/ayon-dependencies-tool/pull/9)
- [OpenPype](https://github.com/ynput/OpenPype/pull/6095)

## Testing notes:
1. Create ayon-launcher installer with this PR
2. Upload installer to server
3. Upload OpenPype addon with required change
4. Create a bundle with the installer and OpenPype addon
5. Create dependency package for the bundle and use it in the bundle
6. Run ayon-launcher with the bundle
7. All should be working