### PR TITLE
Missing dev bundle enhancements

### DIFF
--- a/common/ayon_common/distribution/ui/missing_bundle_window.py
+++ b/common/ayon_common/distribution/ui/missing_bundle_window.py
@@ -167,7 +167,7 @@ def main():
             bundle_name = sys.argv[bundle_index]
 
     if "--user" in sys.argv:
-        user_index = sys.argv.index("--bundle") + 1
+        user_index = sys.argv.index("--user") + 1
         if user_index < len(sys.argv):
             username = sys.argv[user_index]
 

--- a/common/ayon_common/distribution/ui/missing_bundle_window.py
+++ b/common/ayon_common/distribution/ui/missing_bundle_window.py
@@ -18,6 +18,7 @@ class MissingBundleWindow(QtWidgets.QDialog):
         self,
         url=None,
         bundle_name=None,
+        username=None,
         use_staging=None,
         use_dev=None,
         parent=None
@@ -31,6 +32,7 @@ class MissingBundleWindow(QtWidgets.QDialog):
 
         self._url = url
         self._bundle_name = bundle_name
+        self._username = username
         self._use_staging = use_staging
         self._use_dev = use_dev
         self._first_show = True
@@ -68,6 +70,12 @@ class MissingBundleWindow(QtWidgets.QDialog):
         if bundle_name == self._bundle_name:
             return
         self._bundle_name = bundle_name
+        self._update_label()
+
+    def set_username(self, username):
+        if username == self._username:
+            return
+        self._username = username
         self._update_label()
 
     def set_use_staging(self, use_staging):
@@ -123,7 +131,10 @@ class MissingBundleWindow(QtWidgets.QDialog):
         if self._use_staging:
             mode = "staging"
         elif self._use_dev:
-            mode = "dev for your user"
+            if self._username:
+                mode = f"dev for user <b>{self._username}</b>"
+            else:
+                mode = "dev for your user"
         return (
             f"No release bundle is set as {mode} on the AYON"
             f" server{url_part} so there is nothing to launch."
@@ -144,6 +155,7 @@ def main():
 
     url = None
     bundle_name = None
+    username = None
     if "--url" in sys.argv:
         url_index = sys.argv.index("--url") + 1
         if url_index < len(sys.argv):
@@ -154,10 +166,17 @@ def main():
         if bundle_index < len(sys.argv):
             bundle_name = sys.argv[bundle_index]
 
+    if "--user" in sys.argv:
+        user_index = sys.argv.index("--bundle") + 1
+        if user_index < len(sys.argv):
+            username = sys.argv[user_index]
+
     use_staging = is_staging_enabled()
     use_dev = is_dev_mode_enabled()
     app = get_qt_app()
-    window = MissingBundleWindow(url, bundle_name, use_staging, use_dev)
+    window = MissingBundleWindow(
+        url, bundle_name, username, use_staging, use_dev
+    )
     window.show()
     app.exec_()
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -69,7 +69,7 @@ def get_dependencies_dir():
     return dependencies_dir
 
 
-def show_missing_bundle_information(url, bundle_name=None):
+def show_missing_bundle_information(url, bundle_name=None, username=None):
     """Show missing bundle information window.
 
     This function should be called when server does not have set bundle for
@@ -82,6 +82,8 @@ def show_missing_bundle_information(url, bundle_name=None):
     Args:
         url (str): Server url where bundle is not set.
         bundle_name (Optional[str]): Name of bundle that was not found.
+        username (Optional[str]): Username. Is used only when dev mode is
+            enabled.
     """
 
     ui_dir = os.path.join(os.path.dirname(__file__), "ui")
@@ -89,6 +91,8 @@ def show_missing_bundle_information(url, bundle_name=None):
     args = get_ayon_launch_args(script_path, "--skip-bootstrap", "--url", url)
     if bundle_name:
         args.extend(["--bundle", bundle_name])
+    if username:
+        args.extend(["--user", username])
     subprocess.call(args)
 
 

--- a/start.py
+++ b/start.py
@@ -546,6 +546,7 @@ def _start_distribution():
 
     if bundle is None:
         url = get_base_url()
+        username = distribution.active_user
         if bundle_name:
             _print((
                 f"!!! Requested release bundle '{bundle_name}'"
@@ -559,7 +560,7 @@ def _start_distribution():
         else:
             mode = "production"
             if distribution.use_dev:
-                mode = "dev"
+                mode = f"dev for user '{username}'"
             elif distribution.use_staging:
                 mode = "staging"
 
@@ -573,7 +574,7 @@ def _start_distribution():
 
 
         if not HEADLESS_MODE_ENABLED:
-            show_missing_bundle_information(url, bundle_name)
+            show_missing_bundle_information(url, bundle_name, username)
 
         sys.exit(1)
 

--- a/start.py
+++ b/start.py
@@ -546,10 +546,7 @@ def _start_distribution():
 
     if bundle is None:
         url = get_base_url()
-        if not HEADLESS_MODE_ENABLED:
-            show_missing_bundle_information(url, bundle_name)
-
-        elif bundle_name:
+        if bundle_name:
             _print((
                 f"!!! Requested release bundle '{bundle_name}'"
                 " is not available on server."
@@ -573,6 +570,11 @@ def _start_distribution():
                 "!!! Make sure there is a release bundle set"
                 f" as \"{mode}\" on the AYON server '{url}'."
             )
+
+
+        if not HEADLESS_MODE_ENABLED:
+            show_missing_bundle_information(url, bundle_name)
+
         sys.exit(1)
 
     # With known bundle and states we can define default settings variant


### PR DESCRIPTION
## Changelog Description
Dialog shows username when dev bundle is not set. Prints when missing bundle will happen all the time.

### Screenshot
![image](https://github.com/ynput/ayon-launcher/assets/43494761/78ce292a-1857-472b-964e-298f76487dbe)


## Testing notes:
1. Make sure you don't have set dev bundle
2. Start ayon launcher in dev mode
3. It should tell you that you don't have set dev bundle for your user
