### PR TITLE
Login mode

### DIFF
--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -319,7 +319,19 @@ def change_user_ui() -> ChangeUserResult:
          ChangeUserResult: Information about user change.
     """
 
-    from .ui import change_user
+    # For backwards compatibility show dialog that current session does not
+    #   allow credentials change
+    if os.getenv("AYON_IN_LOGIN_MODE") == "0":
+        show_invalid_credentials_ui(in_subprocess=False)
+        return ChangeUserResult(
+            False,
+            os.getenv(SERVER_URL_ENV_KEY),
+            os.getenv(SERVER_API_ENV_KEY),
+            None,
+            None,
+            None,
+            None
+        )
 
     url, username = get_last_server_with_username()
     token = load_token(url)

--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -308,6 +308,38 @@ def ask_to_login_ui(
     return data["output"]
 
 
+def show_login_ui(
+    url: Union[str, None],
+    username: Union[str, None],
+    token: Union[str, None],
+) -> ChangeUserResult:
+    """Show login UI and process inputs.
+
+    Todos:
+        Add more arguments to function to be able to prefill UI with
+            information, like server is unreachable, url is invalid, token is
+            unauthorized, etc.
+
+    Args:
+        url (Union[str, None]): Server url that could be prefilled in UI.
+        username (Union[str, None]): Username that could be prefilled in UI.
+        token (Union[str, None]): User's token that could be prefilled in UI.
+
+    Returns:
+        ChangeUserResult: Information about user change.
+    """
+
+    from .ui import change_user
+
+    result = change_user(url, username, token)
+    new_url, new_token, new_username, logged_out = result
+
+    return ChangeUserResult(
+        logged_out, url, token, username,
+        new_url, new_token, new_username
+    )
+
+
 def change_user_ui() -> ChangeUserResult:
     """Change user using UI.
 
@@ -335,13 +367,7 @@ def change_user_ui() -> ChangeUserResult:
 
     url, username = get_last_server_with_username()
     token = load_token(url)
-    result = change_user(url, username, token)
-    new_url, new_token, new_username, logged_out = result
-
-    output = ChangeUserResult(
-        logged_out, url, token, username,
-        new_url, new_token, new_username
-    )
+    output = show_login_ui(url, username, token)
     if output.logged_out:
         logout(url, token)
 

--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -484,33 +484,34 @@ def is_token_valid(url, token) -> bool:
     return api.has_valid_token
 
 
-def need_server_or_login() -> bool:
+def need_server_or_login() -> tuple[bool, bool]:
     """Check if server url or login to the server are needed.
 
     It is recommended to call 'load_environments' on startup before this check.
     But in some cases this function could be called after startup.
 
     Returns:
-        bool: 'True' if server and token are available. Otherwise 'False'.
+        tuple[bool, bool]: Server or api key needed. Both are 'True' if
+            are available and valid.
     """
 
     server_url = os.environ.get(SERVER_URL_ENV_KEY)
     if not server_url:
-        return True
+        return True, True
 
     try:
         server_url = validate_url(server_url)
     except UrlError:
-        return True
+        return True, True
 
     token = os.environ.get(SERVER_API_ENV_KEY)
     if token:
-        return not is_token_valid(server_url, token)
+        return False, not is_token_valid(server_url, token)
 
     token = load_token(server_url)
     if token:
-        return not is_token_valid(server_url, token)
-    return True
+        return False, not is_token_valid(server_url, token)
+    return False, True
 
 
 def confirm_server_login(url, token, username):

--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -503,7 +503,7 @@ def create_global_connection():
     )
 
 
-def is_token_valid(url, token) -> bool:
+def is_token_valid(url: str, token: str) -> bool:
     """Check if token is valid.
 
     Note:
@@ -555,7 +555,7 @@ def need_server_or_login() -> tuple[bool, bool]:
     return False, True
 
 
-def confirm_server_login(url, token, username):
+def confirm_server_login(url: str, token: str, username: Union[str, None]):
     """Confirm login of user and do necessary stepts to apply changes.
 
     This should not be used on "change" of user but on first login.

--- a/common/ayon_common/connection/ui/__init__.py
+++ b/common/ayon_common/connection/ui/__init__.py
@@ -3,10 +3,17 @@ from .login_window import (
     ask_to_login,
     change_user,
 )
+from .invalid_window import (
+    InvalidCredentialsWindow,
+    invalid_credentials,
+)
 
 
 __all__ = (
     "ServerLoginWindow",
     "ask_to_login",
     "change_user",
+
+    "InvalidCredentialsWindow",
+    "invalid_credentials",
 )

--- a/common/ayon_common/connection/ui/invalid_window.py
+++ b/common/ayon_common/connection/ui/invalid_window.py
@@ -1,0 +1,158 @@
+import os
+import sys
+import json
+
+from qtpy import QtWidgets, QtCore, QtGui
+
+from ayon_common.resources import (
+    get_icon_path,
+    load_stylesheet,
+)
+from ayon_common.ui_utils import get_qt_app
+
+
+class InvalidCredentialsWindow(QtWidgets.QDialog):
+    default_width = 420
+    default_height = 170
+
+    def __init__(self, message, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        icon_path = get_icon_path()
+        icon = QtGui.QIcon(icon_path)
+        self.setWindowIcon(icon)
+        self.setWindowTitle("Invalid credentials")
+
+        info_widget = QtWidgets.QWidget(self)
+
+        message_label = url_cred_sep = None
+        if message:
+            # --- Custom message ---
+            message_label = QtWidgets.QLabel(message, info_widget)
+            message_label.setWordWrap(True)
+            message_label.setTextInteractionFlags(
+                QtCore.Qt.TextBrowserInteraction
+            )
+
+            # --- URL separator ---
+            url_cred_sep = QtWidgets.QFrame(info_widget)
+            url_cred_sep.setObjectName("Separator")
+            url_cred_sep.setMinimumHeight(2)
+            url_cred_sep.setMaximumHeight(2)
+
+        common_label = QtWidgets.QLabel(
+            (
+                " You are running AYON launcher in <b>'bypass login'</b>"
+                " mode. Meaning your AYON connection information is"
+                " defined by environment variables."
+                "<br/><br/>Please contact your administrator or use valid"
+                " credentials."
+            ),
+            info_widget
+        )
+        common_label.setWordWrap(True)
+        common_label.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+
+        info_layout = QtWidgets.QVBoxLayout(info_widget)
+        info_layout.setContentsMargins(0, 0, 0, 0)
+        if message_label is not None:
+            info_layout.addWidget(message_label, 0)
+            info_layout.addWidget(url_cred_sep, 0)
+        info_layout.addWidget(common_label, 0)
+
+        footer_widget = QtWidgets.QWidget(self)
+        close_btn = QtWidgets.QPushButton("Close", footer_widget)
+
+        footer_layout = QtWidgets.QHBoxLayout(footer_widget)
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_layout.addStretch(1)
+        footer_layout.addWidget(close_btn, 0)
+
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.addWidget(info_widget, 0)
+        main_layout.addStretch(1)
+        main_layout.addWidget(footer_widget, 0)
+
+        close_btn.clicked.connect(self._on_close_click)
+
+        self._first_show = True
+        self._message_label = message_label
+        self._common_label = common_label
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        print(self.size())
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if self._first_show:
+            self._first_show = False
+            self._on_first_show()
+
+    def _on_first_show(self):
+        self.setStyleSheet(load_stylesheet())
+        self.resize(self.default_width, self.default_height)
+        self._center_window()
+
+    def _center_window(self):
+        """Move window to center of screen."""
+
+        if hasattr(QtWidgets.QApplication, "desktop"):
+            desktop = QtWidgets.QApplication.desktop()
+            screen_idx = desktop.screenNumber(self)
+            screen_geo = desktop.screenGeometry(screen_idx)
+        else:
+            screen = self.screen()
+            screen_geo = screen.geometry()
+
+        geo = self.frameGeometry()
+        geo.moveCenter(screen_geo.center())
+        if geo.y() < screen_geo.y():
+            geo.setY(screen_geo.y())
+        self.move(geo.topLeft())
+
+    def _on_close_click(self):
+        self.close()
+
+
+def invalid_credentials(message, always_on_top=False):
+    """Tell user that his credentials are invalid.
+
+    This functionality is used when credentials that user did use were
+        not received from keyring or login window.
+
+    Args:
+        message (str): Some information that can caller define.
+        always_on_top (Optional[bool]): Window will be drawn on top of
+            other windows.
+    """
+
+    app_instance = get_qt_app()
+    window = InvalidCredentialsWindow(message)
+    if always_on_top:
+        window.setWindowFlags(
+            window.windowFlags()
+            | QtCore.Qt.WindowStaysOnTopHint
+        )
+
+    if not app_instance.startingUp():
+        window.exec_()
+    else:
+        window.open()
+        # This can become main Qt loop. Maybe should live elsewhere
+        app_instance.exec_()
+
+
+def main(output_path):
+    with open(output_path, "r") as stream:
+        data = json.load(stream)
+
+    os.remove(output_path)
+
+    message = data["message"]
+    always_on_top = data.get("always_on_top", False)
+    invalid_credentials(message, always_on_top=always_on_top)
+
+
+if __name__ == "__main__":
+    main(sys.argv[-1])

--- a/start.py
+++ b/start.py
@@ -405,10 +405,11 @@ def _connect_to_ayon_server(force=False):
     if not force:
         need_server, need_api_key = need_server_or_login()
 
+    current_url = os.environ.get(SERVER_URL_ENV_KEY)
     if not need_server and not need_api_key:
+        _print(f">>> Connected to AYON server {current_url}")
         return
 
-    current_url = os.environ.get(SERVER_URL_ENV_KEY)
     if need_server:
         if current_url:
             message = f"Could not connect to AYON server '{current_url}'."

--- a/start.py
+++ b/start.py
@@ -396,6 +396,10 @@ def _connect_to_ayon_server(force=False):
         force (Optional[bool]): Force login to server.
     """
 
+    if force and HEADLESS_MODE_ENABLED:
+        _print("!!! Login UI was requested in headless mode.")
+        sys.exit(1)
+
     load_environments()
     need_server = need_api_key = True
     if not force:
@@ -415,8 +419,10 @@ def _connect_to_ayon_server(force=False):
     else:
         message = f"Missing API key for '{current_url}'."
 
-    _print("!!! Got invalid credentials.")
-    _print(message)
+    if not force:
+        _print("!!! Got invalid credentials.")
+        _print(message)
+
     # Exit in headless mode
     if HEADLESS_MODE_ENABLED:
         _print((
@@ -874,6 +880,12 @@ def get_info(use_staging=None, use_dev=None) -> list:
 
 def main():
     if SHOW_LOGIN_UI:
+        if HEADLESS_MODE_ENABLED:
+            _print((
+                "!!! Invalid arguments combination"
+                " '--ayon-login' and '--headless'."
+            ))
+            sys.exit(1)
         _connect_to_ayon_server(True)
 
     if SKIP_BOOTSTRAP:

--- a/start.py
+++ b/start.py
@@ -176,6 +176,18 @@ if "--ayon-login" in sys.argv:
     sys.argv.remove("--ayon-login")
     SHOW_LOGIN_UI = True
 
+# Login mode is helper to detect if user is using AYON server credentials
+#   from login UI (and keyring), or from environment variables.
+# - Variable is set in first AYON launcher process for possible subprocesses
+if SHOW_LOGIN_UI:
+    # Make sure login mode is set to '1' when '--ayon-login' is passed
+    os.environ["AYON_IN_LOGIN_MODE"] = "1"
+
+elif "AYON_IN_LOGIN_MODE" not in os.environ:
+    os.environ["AYON_IN_LOGIN_MODE"] = (
+        "0" if "AYON_API_KEY" in os.environ else "1"
+    )
+
 if "--headless" in sys.argv:
     os.environ["AYON_HEADLESS_MODE"] = "1"
     os.environ["OPENPYPE_HEADLESS_MODE"] = "1"
@@ -194,14 +206,6 @@ elif (
 ):
     os.environ["OPENPYPE_HEADLESS_MODE"] = (
         os.environ["AYON_HEADLESS_MODE"]
-    )
-
-# Login mode is helper to detect if user is using AYON server credentials
-#   from login UI (and keyring), or from environment variables.
-# - Variable is set in first AYON launcher process for possible subprocesseses
-if "AYON_IN_LOGIN_MODE" not in os.environ:
-    os.environ["AYON_IN_LOGIN_MODE"] = (
-        "0" if "AYON_API_KEY" in os.environ else "1"
     )
 
 IS_BUILT_APPLICATION = getattr(sys, "frozen", False)


### PR DESCRIPTION
## Changelog Description
Define login mode in ayon launcher to be able determine if credentials are comming from keyring or were defined by environment variables.

## Additional info
Changes are implemented to avoid issues when ayon api key is defined with environment variable. In that case should not be possible to shown login UI, which would show different credentials (or unfilled window). In that case is shown Invalid credentials window with basic information. Login mode will also affect ayon tray. When user clicks on Login, the same dialog is shown.

Added more prints when things go wrong so we get more information, hopefully helpfull on render farm.

### Screenshot
![image](https://github.com/ynput/ayon-launcher/assets/43494761/24d973d6-8d9f-43a3-b57e-e3f51e9a72e4)

### Questions
- Suggestion for env variable name `AYON_IN_LOGIN_MODE`.
- Suggestion for the message shown in dialog are welcomed.
- Different proposal for the solution?

## Testing notes:
1. Set env variables AYON_API_KEY and AYON_SERVER_URL (e.g. in shell or PowerShell)
2. Launch ayon launcher
3. If credentials are invalid, invalid credentials dialog should pop up.
4. If credentials are valid it should launch, but `Login` action in tray will show invalid credentials dialog.
5. Using `--ayon-login` will disregard env variables from shell and login is showed.
    - This will not unset env variables from shell!!! So running again the same process from the same shell will still cause the same issue.