### PR TITLE
Set AYON_SITE_ID environment variable on boot

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -9,6 +9,7 @@ import tarfile
 from uuid import UUID
 
 import appdirs
+from ayon_api.constants import SITE_ID_ENV_KEY
 
 DATE_FMT = "%Y-%m-%d %H:%M:%S"
 CLEANUP_INTERVAL = 2  # days
@@ -85,7 +86,7 @@ def get_local_site_id():
     """
 
     # used for background syncing
-    site_id = os.environ.get("AYON_SITE_ID")
+    site_id = os.environ.get(SITE_ID_ENV_KEY)
     if site_id:
         return site_id
 

--- a/start.py
+++ b/start.py
@@ -289,14 +289,12 @@ from ayon_api import (
     set_default_settings_variant,
     get_addons_studio_settings,
 )
-from ayon_api.constants import SERVER_URL_ENV_KEY, SERVER_API_ENV_KEY
-# Kept for backwards compatibility of older ayon-python-api in case older
-#     is used.
-try:
-    from ayon_api.constants import DEFAULT_VARIANT_ENV_KEY
-except ImportError:
-    DEFAULT_VARIANT_ENV_KEY = "AYON_DEFAULT_SETTINGS_VARIANT"
-
+from ayon_api.constants import (
+    SERVER_URL_ENV_KEY,
+    SERVER_API_ENV_KEY,
+    DEFAULT_VARIANT_ENV_KEY,
+    SITE_ID_ENV_KEY,
+)
 from ayon_common import is_staging_enabled, is_dev_mode_enabled
 from ayon_common.connection.credentials import (
     ask_to_login_ui,
@@ -315,7 +313,10 @@ from ayon_common.distribution import (
     UpdateWindowManager,
 )
 
-from ayon_common.utils import store_current_executable_info
+from ayon_common.utils import (
+    store_current_executable_info,
+    get_local_site_id,
+)
 from ayon_common.startup import show_startup_error
 
 
@@ -643,6 +644,10 @@ def _start_distribution():
 
 def boot():
     """Bootstrap AYON."""
+
+    # Setup site id in environment variable for all possible subprocesses
+    if SITE_ID_ENV_KEY not in os.environ:
+        os.environ[SITE_ID_ENV_KEY] = get_local_site_id()
 
     _connect_to_ayon_server()
     create_global_connection()


### PR DESCRIPTION
## Changelog Description
Set `AYON_SITE_ID` environment variable on start of ayon launcher.

## Additional info
Set the value so any future processes can use it without knowing where to find the information.

## Testing notes:
1. Launcher process from ayon-launcher have set `AYON_SITE_ID` if was not set before launching it.
