### PR TITLE
Remove start.py from sys argv

### DIFF
--- a/start.py
+++ b/start.py
@@ -897,6 +897,10 @@ def script_cli(start_arg=None):
     with open(filepath, "r") as stream:
         content = stream.read()
 
+    # Remove `start.py` argument as this is not expect when running python
+    # scripts.
+    sys.argv.pop(0)
+
     script_globals = dict(globals())
     script_globals["__file__"] = filepath
     exec(compile(content, filepath, "exec"), script_globals)


### PR DESCRIPTION
## Changelog Description
When running python script that uses argparse, the extra argument of the `start.py` file messes up the parsing.

## Testing notes:
1. Setup python script like below:
```python
import argparse


def main():
    # Create ArgumentParser object
    parser = argparse.ArgumentParser(description="Script description")

    # Add arguments
    parser.add_argument(
        "--something", type=str, required=True
    )

    # Parse the arguments
    args = parser.parse_args()
    print(args.something)


if __name__ == "__main__":
    main()
```
2. Run commandline to execute python script in AYON context:
```
.\tools\manage.ps1 run C:\Users\tokejepsen\Desktop\temp.py --something else
```

Error this PR fixes:
```
usage: start.py [-h] --something SOMETHING
start.py: error: unrecognized arguments: C:\Users\tokejepsen\Desktop\temp.py
```