### PR TITLE
Use explicit path to start script instead of first `sys.argv`

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -117,7 +117,7 @@ def get_ayon_launch_args(*args):
 
     output = [sys.executable]
     if not IS_BUILT_APPLICATION:
-        output.append(sys.argv[0])
+        output.append(os.path.join(os.environ["AYON_ROOT"], "start.py"))
     output.extend(args)
     return output
 


### PR DESCRIPTION
## Changelog Description
First `sys.argv` may not be set correctly to `start.py` after bootstrap args manipulation. Using expicit path avoids possible issues.

## Testing notes:
1. Login dialog should show correctly when running from code and user is not logged in.
