### PR TITLE
MacOS build: Codesign auto fix

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -265,13 +265,21 @@ build_ayon () {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     macoscontents="$repo_root/build/AYON $ayon_version.app/Contents"
     macosdir="$macoscontents/MacOS"
-
+    ayonexe="$macosdir/ayon"
+    tmp_ayonexe="$macosdir/ayon_tmp"
     # force hide icon from Dock
     defaults write "$macoscontents/Info" LSUIElement 1
 
+    # Fix codesign bug by creating copy of executable, removing source
+    #   executable and replacing by the copy
+    #   - this will clear cache of codesign
+    cp $ayonexe $tmp_ayonexe
+    rm $ayonexe
+    mv $tmp_ayonexe $ayonexe
+
     # fix code signing issue
     echo -e "${BIGreen}>>>${RST} Fixing code signatures ...\c"
-    codesign --remove-signature "$macosdir/ayon" || { echo -e "${BIRed}FAILED${RST}"; return 1; }
+    codesign --remove-signature $ayonexe || { echo -e "${BIRed}FAILED${RST}"; return 1; }
   fi
 
   if [[ "$should_make_installer" == 1 ]]; then

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -273,13 +273,13 @@ build_ayon () {
     # Fix codesign bug by creating copy of executable, removing source
     #   executable and replacing by the copy
     #   - this will clear cache of codesign
-    cp $ayonexe $tmp_ayonexe
-    rm $ayonexe
-    mv $tmp_ayonexe $ayonexe
+    cp "$ayonexe" "$tmp_ayonexe"
+    rm "$ayonexe"
+    mv "$tmp_ayonexe" "$ayonexe"
 
     # fix code signing issue
     echo -e "${BIGreen}>>>${RST} Fixing code signatures ...\c"
-    codesign --remove-signature $ayonexe || { echo -e "${BIRed}FAILED${RST}"; return 1; }
+    codesign --remove-signature "$ayonexe" || { echo -e "${BIRed}FAILED${RST}"; return 1; }
   fi
 
   if [[ "$should_make_installer" == 1 ]]; then


### PR DESCRIPTION
## Changelog Description
Autofix issue with removing signature from ayon executable.

## Additional info
As I understood the issue: Codesign uses cache of executables, and when cx freeze is creating ayon executable it stores some cache that prevents from removing the signature. And removing the executable will clear the cache. So a copy of executable is created, then is removed the source executable to clear cache, and then is renameed the temp copy to the origin name. With this codesign does not crash.

## Testing notes:
1. Running `./tools/make.sh build` should work without any issues
