### PR TITLE
Show error of dependency package

### DIFF
--- a/common/ayon_common/startup/__init__.py
+++ b/common/ayon_common/startup/__init__.py
@@ -7,7 +7,7 @@ import tempfile
 from ayon_common.utils import get_ayon_launch_args
 
 
-def show_startup_error(title, message):
+def show_startup_error(title, message, detail=None):
     """Show startup error message.
 
     This will trigger a subprocess with UI message dialog.
@@ -26,7 +26,14 @@ def show_startup_error(title, message):
         filepath = tmp.name
 
     with open(filepath, "w") as stream:
-        json.dump({"title": title, "message": message}, stream)
+        json.dump(
+            {
+                "title": title,
+                "message": message,
+                "detail": detail,
+            },
+            stream
+        )
 
     args = get_ayon_launch_args(
         script_path, "--skip-bootstrap", filepath

--- a/common/ayon_common/startup/ui/startup_error.py
+++ b/common/ayon_common/startup/ui/startup_error.py
@@ -1,7 +1,7 @@
 import sys
 import json
 
-from qtpy import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui, QtCore
 
 from ayon_common.resources import (
     get_icon_path,
@@ -14,7 +14,7 @@ class MessageWindow(QtWidgets.QDialog):
     default_width = 410
     default_height = 170
 
-    def __init__(self, title, message, parent=None):
+    def __init__(self, title, message, detail, parent=None):
         super().__init__(parent)
 
         icon_path = get_icon_path()
@@ -37,9 +37,28 @@ class MessageWindow(QtWidgets.QDialog):
         info_label = QtWidgets.QLabel(message, info_widget)
         info_label.setWordWrap(True)
 
+        details_wrapper = QtWidgets.QWidget(info_widget)
+
+        details_separator = QtWidgets.QFrame(details_wrapper)
+        details_separator.setObjectName("Separator")
+        details_separator.setMinimumHeight(2)
+        details_separator.setMaximumHeight(2)
+
+        details_widget = QtWidgets.QLabel(details_wrapper)
+        details_widget.setWordWrap(True)
+        details_widget.setTextInteractionFlags(
+            QtCore.Qt.TextBrowserInteraction
+        )
+
+        details_wrapper_layout = QtWidgets.QVBoxLayout(details_wrapper)
+        details_wrapper_layout.setContentsMargins(0, 0, 0, 0)
+        details_wrapper_layout.addWidget(details_separator, 0)
+        details_wrapper_layout.addWidget(details_widget, 0)
+
         info_layout = QtWidgets.QVBoxLayout(info_widget)
         info_layout.setContentsMargins(0, 0, 0, 0)
         info_layout.addWidget(info_label, 0)
+        info_layout.addWidget(details_wrapper, 0)
         info_layout.addStretch(1)
 
         body_layout = QtWidgets.QHBoxLayout(body_widget)
@@ -61,8 +80,14 @@ class MessageWindow(QtWidgets.QDialog):
 
         confirm_btn.clicked.connect(self._on_confirm_click)
 
+        if detail:
+            details_widget.setText(detail)
+        else:
+            details_wrapper.setVisible(False)
+
         self._icon_label = icon_label
         self._confirm_btn = confirm_btn
+        self._details_widget = details_widget
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -111,7 +136,7 @@ def main():
         data = json.load(stream)
 
     app = get_qt_app()
-    window = MessageWindow(data["title"], data["message"])
+    window = MessageWindow(data["title"], data["message"], data["detail"])
     window.show()
     app.exec_()
 

--- a/start.py
+++ b/start.py
@@ -739,7 +739,7 @@ def _on_main_addon_missing():
     sys.exit(1)
 
 
-def _on_main_addon_import_error():
+def _on_main_addon_import_error(exception):
     if HEADLESS_MODE_ENABLED:
         raise RuntimeError(
             "Failed to import AYON core addon. Probably because"
@@ -752,7 +752,8 @@ def _on_main_addon_import_error():
             " addons."
             "<br/><br/>Please contact your administrator"
             " to resolve the issue."
-        )
+        ),
+        str(exception)
     )
     sys.exit(1)
 
@@ -765,8 +766,9 @@ def _main_cli_openpype():
 
     try:
         from openpype import cli
-    except ImportError:
-        _on_main_addon_import_error()
+    except ImportError as exc:
+        traceback.print_exception(*sys.exc_info())
+        _on_main_addon_import_error(exc)
 
     python_path = os.getenv("PYTHONPATH", "")
     split_paths = python_path.split(os.pathsep)
@@ -835,8 +837,9 @@ def main_cli():
 
     try:
         from ayon_core import cli
-    except ImportError:
-        _on_main_addon_import_error()
+    except ImportError as exc:
+        traceback.print_exception(*sys.exc_info())
+        _on_main_addon_import_error(exc)
 
     # print info when not running scripts defined in 'silent commands'
     if not SKIP_HEADERS:


### PR DESCRIPTION
## Changelog Description
Print traceback when import of main addon crashes because of `ImportError` and show the message from exception in UI.

## Screenshot
![image](https://github.com/ynput/ayon-launcher/assets/43494761/f218afda-1d5a-4b59-9795-1d4c69ec13d5)

## Testing notes:
1. Use invalid dependency package (use one of older ones), or fake `ImportError` in ayon core or openpype.
2. Traceback should be printed.
3. UI should show the error message.
