### PR TITLE
Pip freeze fix

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -255,6 +255,7 @@ build_ayon () {
   fi
   echo -e "${BIGreen}>>>${RST} Building ..."
   "$POETRY_HOME/bin/poetry" run python -m pip --no-color freeze > "$repo_root/build/requirements.txt"
+  "$POETRY_HOME/bin/poetry" export --without-urls --without-hashes -f requirements.txt -n --no-ansi > "$repo_root/build/poetry_requirements.txt"
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     "$POETRY_HOME/bin/poetry" run python "$repo_root/setup.py" build &> "$repo_root/build/build.log" || { echo -e "${BIRed}------------------------------------------${RST}"; cat "$repo_root/build/build.log"; echo -e "${BIRed}------------------------------------------${RST}"; echo -e "${BIRed}!!!${RST} Build failed, see the build log."; return 1; }
   elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -350,9 +350,11 @@ function Build-Ayon($MakeInstaller = $false) {
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
     $FreezeContent = & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze
+    $FreezeContentPoetry = & "$($env:POETRY_HOME)\bin\poetry" export --without-urls --without-hashes -f requirements.txt -n --no-ansi
     # Make sure output is UTF-8 without BOM
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines("$($repo_root)\build\requirements.txt", $FreezeContent, $Utf8NoBomEncoding)
+    [System.IO.File]::WriteAllLines("$($repo_root)\build\poetry_requirements.txt", $FreezeContentPoetry, $Utf8NoBomEncoding)
 
     $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out


### PR DESCRIPTION
## Changelog Description
Requirements in installer json do contain correct git urls.

## Additional info
Since pip version 24, freeze does not seem to handle git urls, and stores filepath to source package instead. This PR uses combination of requirements from venv and export from poetry.

This is not ideal solution, but should be working.
