### PR TITLE
Remove first argument when running script

### DIFF
--- a/start.py
+++ b/start.py
@@ -913,8 +913,8 @@ def script_cli(start_arg=None):
         start_arg = StartArgScript.from_args(sys.argv)
 
     # Remove first argument from sys.argv
-    # - start.py when running from code and ayon executable whne running
-    #   from build
+    # - start.py when running from code 
+    # - ayon executable when running from build
     sys.argv.pop(0)
 
     # Find '__main__.py' in directory

--- a/start.py
+++ b/start.py
@@ -912,6 +912,11 @@ def script_cli(start_arg=None):
     if start_arg is None:
         start_arg = StartArgScript.from_args(sys.argv)
 
+    # Remove first argument from sys.argv
+    # - start.py when running from code and ayon executable whne running
+    #   from build
+    sys.argv.pop(0)
+
     # Find '__main__.py' in directory
     if not start_arg.is_valid:
         if not start_arg.argument:


### PR DESCRIPTION
## Changelog Description
Content of `sys.argv` does not contain start.py script or ayon-launcher executable.

## Additional information
Reopened https://github.com/ynput/ayon-launcher/pull/94 . Changes in ayon-core were made and this change should be safe to do now.

This change might be done globaly in future PRs, now I'm too scared to do so.

## Testing notes:
1. Setup python script like below:
```python
import argparse


def main():
    # Create ArgumentParser object
    parser = argparse.ArgumentParser(description="Script description")

    # Add arguments
    parser.add_argument(
        "--something", type=str, required=True
    )

    # Parse the arguments
    args = parser.parse_args()
    print(args.something)


if __name__ == "__main__":
    main()
```
2. Run commandline to execute python script in AYON context:
```
.\tools\manage.ps1 run C:\Users\tokejepsen\Desktop\temp.py --something else
```

Error this PR fixes:
```
usage: start.py [-h] --something SOMETHING
start.py: error: unrecognized arguments: C:\Users\tokejepsen\Desktop\temp.py
```
