### PR TITLE
Chore: Update to PySide6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build AYON docker image
 FROM ubuntu:focal AS builder
-ARG PYTHON_VERSION=3.9.12
+ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -105,4 +105,4 @@ RUN cp /usr/lib64/libffi* ./build/output/lib \
     && ln -sr ./build/output/lib/libssl.so ./build/output/lib/libssl.1.1.so \
     && ln -sr ./build/output/lib/libcrypto.so ./build/output/lib/libcrypto.1.1.so \
     && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/output/lib \
-    && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide6/Qt/lib
+    && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide2/Qt/lib

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,6 +1,6 @@
 # Build AYON launcher docker image
 FROM centos:7 AS builder
-ARG PYTHON_VERSION=3.9.12
+ARG PYTHON_VERSION=3.9.13
 
 LABEL description="Docker Image to build and run AYON Launcher under Centos 7"
 LABEL org.opencontainers.image.name="ynput/ayon-launcher"

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -89,6 +89,8 @@ RUN chmod +x /opt/ayon-launcher/tools/make.sh
 
 WORKDIR /opt/ayon-launcher
 
+ENV QT_BINDING=centos7
+
 RUN source $HOME/.bashrc \
     && pyenv local ${PYTHON_VERSION}
 
@@ -103,4 +105,4 @@ RUN cp /usr/lib64/libffi* ./build/output/lib \
     && ln -sr ./build/output/lib/libssl.so ./build/output/lib/libssl.1.1.so \
     && ln -sr ./build/output/lib/libcrypto.so ./build/output/lib/libcrypto.1.1.so \
     && cp /root/.pyenv/versions/${PYTHON_VERSION}/lib/libpython* ./build/output/lib \
-    && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide2/Qt/lib
+    && cp /usr/lib64/libxcb* ./build/output/vendor/python/PySide6/Qt/lib

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,6 @@
 # Build Pype docker image
 FROM debian:bullseye AS builder
-ARG PYTHON_VERSION=3.9.12
+ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -1,6 +1,6 @@
 # Build AYON launcher docker image
 FROM rockylinux:9 AS builder
-ARG PYTHON_VERSION=3.9.16
+ARG PYTHON_VERSION=3.9.13
 
 LABEL description="Docker Image to build and run AYON Launcher under RockyLinux 9"
 LABEL org.opencontainers.image.name="ynput/ayon-launcher"

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -40,8 +40,7 @@ RUN dnf -y install \
         autoconf \
         patch \
         ncurses \
-	ncurses-devel \
-        qt5-qtbase-devel \
+        ncurses-devel \
         xcb-util-wm \
         xcb-util-renderutil \
     && dnf clean all

--- a/docs/build_guides/linux.md
+++ b/docs/build_guides/linux.md
@@ -32,17 +32,18 @@ In case you run in error about `xcb` when running AYON,
 you'll need also additional libraries for Qt5:
 
 ```sh
-sudo apt install qt5-default
+sudo apt install qt6-default
 ```
-or if you are on Ubuntu > 20.04, there is no `qt5-default` packages so you need to install its content individually:
+or if you are on Ubuntu > 20.04, there is no `qt6-default` packages so you need to install its content individually:
 
 ```sh
-sudo apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+sudo apt-get install qtbase6-dev qtchooser qt6-qmake qtbase6-dev-tools
 ```
 </details>
 
 <details>
-<summary>Details for Centos</summary>
+<summary>Details for Centos 7</summary>
+Note that centos 7 is old OS and some of the packages are not available so there might be used older versions. For example still uses PySide2 instead of PySide6.
 Install git, cmake and curl
 
 ```sh

--- a/docs/build_guides/linux.md
+++ b/docs/build_guides/linux.md
@@ -112,7 +112,7 @@ git clone --recurse-submodules git@github.com:ynput/ayon-launcher.git
 Create virtual environment in `./.venv` and install python runtime dependencies like PySide, Pillow..
 
 **For Centos:**
-Centos does not support default version of PySide6. We've prepared last supported version, all you need to do is to set environment variable `QT_BINDING` to `centor7`.
+Centos does not support default version of PySide6. We've prepared last supported version, all you need to do is to set environment variable `QT_BINDING` to `centos7`.
 
 ```
 ./tools/make.sh create-env

--- a/docs/build_guides/linux.md
+++ b/docs/build_guides/linux.md
@@ -110,6 +110,10 @@ git clone --recurse-submodules git@github.com:ynput/ayon-launcher.git
 
 #### Prepare environment
 Create virtual environment in `./.venv` and install python runtime dependencies like PySide, Pillow..
+
+**For Centos:**
+Centos does not support default version of PySide6. We've prepared last supported version, all you need to do is to set environment variable `QT_BINDING` to `centor7`.
+
 ```
 ./tools/make.sh create-env
 ./tools/make.sh install-runtime-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,10 @@ version = "6.7.1"
 package = "PySide6"
 version = "6.7.1"
 
+[ayon.qtbinding.centos7]
+package = "PySide6"
+version = "6.2.4"
+
 [tool.pyright]
 include = [
     "vendor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,16 +82,16 @@ build-backend = "poetry.core.masonry.api"
 # Poetry will support custom location (-t flag for pip)
 # https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers
 [ayon.qtbinding.windows]
-package = "PySide2"
-version = "5.15.2"
+package = "PySide6"
+version = "6.7.1"
 
 [ayon.qtbinding.darwin]
 package = "PySide6"
-version = "6.4.3"
+version = "6.7.1"
 
 [ayon.qtbinding.linux]
-package = "PySide2"
-version = "5.15.2"
+package = "PySide6"
+version = "6.7.1"
 
 [tool.pyright]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,8 @@ package = "PySide6"
 version = "6.7.1"
 
 [ayon.qtbinding.centos7]
-package = "PySide6"
-version = "6.2.4"
+package = "PySide2"
+version = "5.15.2"
 
 [tool.pyright]
 include = [

--- a/tools/runtime_dependencies.py
+++ b/tools/runtime_dependencies.py
@@ -95,9 +95,15 @@ def _pip_install(runtime_dep_root, package, version=None):
 
 def install_qtbinding(pyproject, runtime_dep_root, platform_name):
     _print("Handling Qt binding framework ...")
-    qtbinding_def = pyproject["ayon"]["qtbinding"][platform_name]
+
+    qt_package = os.getenv("QT_BINDING")
+    qt_binding_options = pyproject["ayon"]["qtbinding"]
+    qtbinding_def = qt_binding_options.get(qt_package)
+    if not qtbinding_def:
+        qtbinding_def = pyproject["ayon"]["qtbinding"][platform_name]
     package = qtbinding_def["package"]
     version = qtbinding_def.get("version")
+
     _pip_install(runtime_dep_root, package, version)
 
     # Remove libraries for QtSql which don't have available libraries


### PR DESCRIPTION
## Changelog Description
Use PySide6 on all platforms.

## Additional info
Because centos 7 does not support latest versions of PySide6 it was necessary to keep it at PySide2.

## Testing notes:
    - delete `vendor` in ayon-launcher
    - run `ayon-launcher/tools/manage.ps1 install-runtime` 
1. Build on any affected platform (windows and linux distributions).
2. Install and run.
4. All UIs should work as expected.
(You could make sure you are running PySide6 in Tray > Admin > Console:
```
import PySide6
print(PySide6.__version__)
```
shouldnt fail and print 6.7.1 (on Windows)
