### PR TITLE
Windows build: Enable 'include_msvcr'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,7 @@ if IS_WINDOWS:
             icon=icon_path.as_posix()
         )
     )
+    build_exe_options["include_msvcr"] = True
 
 if IS_LINUX:
     executables.append(


### PR DESCRIPTION
## Changelog Description
Enable `include_msvcr` to include `vcruntime140.dll` in build.

## Additional info
Some windows distributions don't have the dll by default.
