### PR TITLE
Chore: Update ayon python api

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -272,21 +272,20 @@ tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "ayon-python-api"
-version = "1.0.1"
+version = "1.0.7"
 description = "AYON Python API"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "ayon-python-api-1.0.1.tar.gz", hash = "sha256:6a53af84903317e2097f3c6bba0094e90d905d6670fb9c7d3ad3aa9de6552bc1"},
-    {file = "ayon_python_api-1.0.1-py3-none-any.whl", hash = "sha256:d4b649ac39c9003cdbd60f172c0d35f05d310fba3a0649b6d16300fe67f967d6"},
+    {file = "ayon-python-api-1.0.7.tar.gz", hash = "sha256:3475538792a783cd01150b8ce73f309beb2fd202551ed8c085484cf5bd9425d9"},
+    {file = "ayon_python_api-1.0.7-py3-none-any.whl", hash = "sha256:3559018bb5ce39f5cb709cfb3ddc123f4643670cd22a76d0016694732dcba37b"},
 ]
 
 [package.dependencies]
 appdirs = ">=1,<2"
 requests = ">=2.27.1"
-six = ">=1.15"
-Unidecode = ">=1.2.0"
+Unidecode = ">=1.3.0"
 
 [[package]]
 name = "babel"
@@ -2217,14 +2216,14 @@ test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
 name = "unidecode"
-version = "1.2.0"
+version = "1.3.8"
 description = "ASCII transliterations of Unicode text"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.5"
 files = [
-    {file = "Unidecode-1.2.0-py2.py3-none-any.whl", hash = "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00"},
-    {file = "Unidecode-1.2.0.tar.gz", hash = "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d"},
+    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
+    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python = ">=3.9.1,<3.10"
 # ayon python api
 ayon-python-api = "*"
 arrow = "^0.17"
-Unidecode = "1.2.0"
+Unidecode = "^1.2.0"
 aiohttp = "^3.7"
 # local settings
 appdirs = { git = "https://github.com/ActiveState/appdirs.git", branch = "master" }


### PR DESCRIPTION
## Changelog Description
Updated ayon-python-api to 1.0.7 and unidecode to 1.3.8 which is required by newer versoin of ayon-python-api.
