### PR TITLE
WebActions: Launcher can handle webactions

### DIFF
--- a/common/ayon_common/_windows_register_scheme.py
+++ b/common/ayon_common/_windows_register_scheme.py
@@ -152,19 +152,24 @@ def _needs_update(shim_icon_path, shim_command):
     return False
 
 
+def _get_shim_icon(shim_path: str) -> str:
+    return subprocess.list2cmdline([shim_path])
+
+
+def _get_shim_command(shim_path: str) -> str:
+    cmd = subprocess.list2cmdline([shim_path])
+    return f'{cmd} "%1"'
+
+
 def is_reg_set(shim_path: str) -> bool:
-    shim_icon_path = subprocess.list2cmdline([shim_path])
-    shim_command = subprocess.list2cmdline([
-        shim_path, '"%1"'
-    ])
+    shim_icon_path = _get_shim_icon(shim_path)
+    shim_command = _get_shim_command(shim_path)
     return not _needs_update(shim_icon_path, shim_command)
 
 
 def set_reg(shim_path: str) -> bool:
-    shim_icon_path = subprocess.list2cmdline([shim_path])
-    shim_command = subprocess.list2cmdline([
-        shim_path, '"%1"'
-    ])
+    shim_icon_path = _get_shim_icon(shim_path)
+    shim_command = _get_shim_command(shim_path)
     if _needs_update(shim_icon_path, shim_command):
         return _update_reg(shim_icon_path, shim_command)
     return True

--- a/common/ayon_common/_windows_register_scheme.py
+++ b/common/ayon_common/_windows_register_scheme.py
@@ -1,0 +1,152 @@
+import os
+import sys
+import subprocess
+
+import winreg
+
+SCRIPT_PATH = os.path.abspath(__file__)
+PROTOCOL_NAME = "ayon-launcher"
+_REG_ICON_PATH = "\\".join([PROTOCOL_NAME, "DefaultIcon"])
+_REG_COMMAND_PATH = "\\".join([PROTOCOL_NAME, "shell", "open", "command"])
+
+
+def _reg_exists(root, path):
+    try:
+        handle = winreg.OpenKey(
+            root,
+            path,
+            0,
+            winreg.KEY_READ
+        )
+        handle.Close()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _update_reg_in_subprocess():
+    import win32con
+    import win32process
+    import win32event
+    import pywintypes
+    from win32comext.shell.shell import ShellExecuteEx
+    from win32comext.shell import shellcon
+
+    executable = sys.executable
+    command = subprocess.list2cmdline([SCRIPT_PATH])
+    try:
+        process_info = ShellExecuteEx(
+            nShow=win32con.SW_SHOWNORMAL,
+            fMask=shellcon.SEE_MASK_NOCLOSEPROCESS,
+            lpVerb="runas",
+            lpFile=executable,
+            lpParameters=command,
+            lpDirectory=os.path.dirname(executable)
+        )
+
+    except pywintypes.error:
+        # User cancelled UAC dialog
+        return False
+
+    process_handle = process_info["hProcess"]
+    win32event.WaitForSingleObject(process_handle, win32event.INFINITE)
+    returncode = win32process.GetExitCodeProcess(process_handle)
+    return returncode == 0
+
+
+def _update_reg(shim_icon_path, shim_command):
+    try:
+        with winreg.CreateKeyEx(
+            winreg.HKEY_CLASSES_ROOT,
+            PROTOCOL_NAME,
+            access=winreg.KEY_WRITE
+        ) as key:
+            winreg.SetValueEx(
+                key, "URL Protocol", 0, winreg.REG_SZ, ""
+            )
+    except PermissionError:
+        return _update_reg_in_subprocess()
+
+    with winreg.CreateKeyEx(
+        winreg.HKEY_CLASSES_ROOT,
+        _REG_ICON_PATH,
+        access=winreg.KEY_WRITE
+    ) as key:
+        winreg.SetValueEx(
+            key, "", 0, winreg.REG_SZ, shim_icon_path
+        )
+
+    with winreg.CreateKeyEx(
+        winreg.HKEY_CLASSES_ROOT,
+        _REG_COMMAND_PATH,
+        access=winreg.KEY_WRITE
+    ) as key:
+        winreg.SetValueEx(
+            key, "", 0, winreg.REG_SZ, shim_command
+        )
+    return True
+
+
+def _needs_update(shim_icon_path, shim_command):
+    # Validate existence of all required registry keys
+    if (
+        not _reg_exists(winreg.HKEY_CLASSES_ROOT, PROTOCOL_NAME)
+        or not _reg_exists(winreg.HKEY_CLASSES_ROOT, _REG_ICON_PATH)
+        or not _reg_exists(winreg.HKEY_CLASSES_ROOT, _REG_COMMAND_PATH)
+    ):
+        return True
+
+    # Check if protocol has set version
+    with winreg.OpenKey(
+        winreg.HKEY_CLASSES_ROOT,
+        PROTOCOL_NAME,
+        0,
+        winreg.KEY_READ
+    ) as key:
+        _, values_count, _ = winreg.QueryInfoKey(key)
+        if not values_count:
+            return True
+
+    with winreg.OpenKey(
+        winreg.HKEY_CLASSES_ROOT,
+        _REG_ICON_PATH,
+        0,
+        winreg.KEY_READ
+    ) as key:
+        value, _ = winreg.QueryValueEx(key, "")
+        if not value:
+            return True
+
+        if value != shim_icon_path:
+            return True
+
+    with winreg.OpenKey(
+        winreg.HKEY_CLASSES_ROOT,
+        _REG_COMMAND_PATH,
+        0,
+        winreg.KEY_READ
+    ) as key:
+        value, _ = winreg.QueryValueEx(key, "")
+        if not value:
+            return True
+        if value != shim_command:
+            return True
+    return False
+
+
+def is_reg_set(shim_path: str) -> bool:
+    shim_icon_path = subprocess.list2cmdline([shim_path])
+    shim_command = subprocess.list2cmdline([
+        shim_path, "uri-protocol", "%1"
+    ])
+    return not _needs_update(shim_icon_path, shim_command)
+
+
+def set_reg(shim_path: str) -> bool:
+    shim_icon_path = subprocess.list2cmdline([shim_path])
+    shim_command = subprocess.list2cmdline([
+        shim_path, "uri-protocol", "%1"
+    ])
+    if _needs_update(shim_icon_path, shim_command):
+        return _update_reg(shim_icon_path, shim_command)
+    return True

--- a/common/ayon_common/_windows_register_scheme.py
+++ b/common/ayon_common/_windows_register_scheme.py
@@ -155,7 +155,7 @@ def _needs_update(shim_icon_path, shim_command):
 def is_reg_set(shim_path: str) -> bool:
     shim_icon_path = subprocess.list2cmdline([shim_path])
     shim_command = subprocess.list2cmdline([
-        shim_path, "%1"
+        shim_path, '"%1"'
     ])
     return not _needs_update(shim_icon_path, shim_command)
 
@@ -163,7 +163,7 @@ def is_reg_set(shim_path: str) -> bool:
 def set_reg(shim_path: str) -> bool:
     shim_icon_path = subprocess.list2cmdline([shim_path])
     shim_command = subprocess.list2cmdline([
-        shim_path, "%1"
+        shim_path, '"%1"'
     ])
     if _needs_update(shim_icon_path, shim_command):
         return _update_reg(shim_icon_path, shim_command)

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -629,6 +629,18 @@ def validate_file_checksum(filepath, checksum, checksum_algorithm):
 
 
 # --- SHIM information ---
+def is_windows_launcher_protocol_registered():
+    from ._windows_register_scheme import is_reg_set
+
+    return is_reg_set()
+
+
+def register_windows_launcher_protocol():
+    from ._windows_register_scheme import set_reg
+
+    return set_reg(get_shim_executable_path())
+
+
 def _get_shim_executable_root():
     """Root to shim executable.
 
@@ -700,7 +712,9 @@ def _deploy_shim_windows(installer_shim_root, create_desktop_icons):
     if create_desktop_icons:
         args.append('/TASKS="desktopicon"')
     code = subprocess.call(args)
-    return code == 0
+    if code != 0:
+        return False
+    return register_windows_launcher_protocol()
 
 
 def _deploy_shim_linux(installer_shim_root):

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -67,7 +67,7 @@ Filename: "{app}\ayon.exe"; Description: "{cm:LaunchProgram,AYON}"; Flags: nowai
 procedure AfterInstallProc();
 var
   ResultCode: Integer;
-  Command: String;
+  ExecParams: String;
   OutputFilepath: String;
   InstallDir: String;
 begin
@@ -75,8 +75,8 @@ begin
   if WizardIsTaskSelected('desktopicon') then
   begin
     ExecParams := ExecParams + ' --create-desktop-icons';
-  end
-  Exec(ExpandConstant('{app}\ayon.exe'), ExecParams, '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+  end;
+  Exec(ExpandConstant('{app}\ayon.exe'), ExecParams, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   OutputFilepath := GetEnv('AYON_INSTALL_EXE_OUTPUT');
   InstallDir := ExpandConstant('{app}');
   if Length(OutputFilepath) > 0 then

--- a/shim/ayon.desktop
+++ b/shim/ayon.desktop
@@ -7,6 +7,7 @@ Exec={ayon_exe_root}/ayon %u
 Icon={ayon_exe_root}/AYON.png
 Terminal=false
 Type=Application
+MimeType=application/ayon-launcher;
 SingleMainWindow=false
 Keywords=AYON;
 Actions=Staging;

--- a/start.py
+++ b/start.py
@@ -878,8 +878,12 @@ def process_uri():
     env["AYON_IN_LOGIN_MODE"] = "1"
 
     # Add executable to args
-    args = data["args"]
-    args.insert(0, sys.executable)
+    uri_args = data["args"]
+    args = [sys.executable]
+    if not IS_BUILT_APPLICATION:
+        args.append(os.path.abspath(__file__))
+    args += uri_args
+
     kwargs = {"env": env}
     low_platform = platform.system().lower()
     if low_platform == "darwin":


### PR DESCRIPTION
## Changelog Description
AYON launcher is capable of handling `ayon-launcher` scheme using shims.

## Additional info
AYON launcher is handling `ayon-launcher` scheme. On all platfrorms is the handling done using shim as startup executable. This way we have only one executable registered for handling of the scheme without being worried about different AYON launcher versions.

On macOs is scheme defined in shim's plist. On linux we use `ayon.desktop` which is also used for showing shortcut in apps menu. On windows is necessary to register the scheme, for that is necessary to have admin privileges and installation of shims will ask for them. At this moment this happens only on first shim installation, and there is no easy way how to register it afterwards.

We can prepare .reg file for windows admins so they can easily deploy and register shims without huge amount of job (or maybe just add expected content of reg file to README.md).

## Testing notes:
1. Make sure you have AYON server with these branches https://github.com/ynput/ayon-backend/pull/183 and https://github.com/ynput/ayon-frontend/pull/563 .
2.  If you've already tested https://github.com/ynput/ayon-launcher/pull/112 then remove existing deployed shim (%LOCALAPPDATA%\Ynput\AYON\shim\`).
3. Remove `.poetry`, `.venv` and `vendor` folders in AYON launcher root.
4. Run `./tools/manage.ps1 create-env`.
5. Run `./tools/manage.ps1 install-runtime`.
6. Run `./tools/manage.ps1 build-make-installer`.
7. If all successfully finished then upload installer to your AYON server and install it.
8. Install ayon-applications addon from this PR https://github.com/ynput/ayon-applications/pull/1 and restart server.
9. Use it in your production or develop bundle.
10. Select a task of your choice.
11. You should see applications actions (If you have checked Develop mode, then you'll see actions from dev bundle),
12. Run one of them.

## Advanced testing notes:
You don't have to have build AYON launcher for testing webactions on windows. It is possible to point to a powershell script and create schema handler manually. It must be powershell, because .bat file handles `&` in argument as "execute following string".

Create `<ayon-launcher>/tools/ayon_console.ps1` with this content:
```powershell
$current_dir = Get-Location
$script_dir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
$repo_root = (Get-Item $script_dir).parent.FullName
$poetry_home = "$repo_root\.poetry"

Set-Location -Path $repo_root

$arguments=@()
for ($i=0; $i -lt $args.Length; $i++)
{
    $arg = $args[$i].Replace("&", "^&")
    $arguments += $arg
}
try {
    & $poetry_home\bin\poetry.exe run python "$( $repo_root )\start.py" $arguments
} finally {
    Set-Location -Path $current_dir
}
```

Create file `ayon-launcher.reg` with this content (replace `<FILL THIS PATH>` with your path) and open the file.
```
Windows Registry Editor Version 5.00

[HKEY_CLASSES_ROOT\ayon-launcher]
"URL Protocol"=""

[HKEY_CLASSES_ROOT\ayon-launcher\DefaultIcon]
@="<FILL THIS PATH>\\ayon-launcher\\common\\ayon_common\\resources\\AYON.ico"

[HKEY_CLASSES_ROOT\ayon-launcher\shell]

[HKEY_CLASSES_ROOT\ayon-launcher\shell\open]

[HKEY_CLASSES_ROOT\ayon-launcher\shell\open\command]
@="Powershell.exe -File "<FILL THIS PATH>\\ayon-launcher\\tools\\ayon_console.ps1" \"%1\""

```
