### PR TITLE
Distribution: Don't use addon details

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1420,7 +1420,7 @@ class AyonDistribution:
         """
 
         if self._addons_info is NOT_SET:
-            server_info = ayon_api.get_addons_info(details=True)
+            server_info = ayon_api.get_addons_info(details=False)
             self._addons_info = server_info["addons"]
         return self._addons_info
 


### PR DESCRIPTION
## Changelog Description
Don't fetch addon information with details.

## Additional info
We're getting addons with all details which are not used, but the speed difference is significant (at about 0.8 seconds).

## Testing notes:
1. Bootstrap should be a little bit faster.
