### PR TITLE
Chore: Ignore empty value of 'AYON_BUNDLE_NAME' env variable

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -929,7 +929,7 @@ class AyonDistribution:
         )
 
         if bundle_name is NOT_SET:
-            bundle_name = os.environ.get("AYON_BUNDLE_NAME", NOT_SET)
+            bundle_name = os.environ.get("AYON_BUNDLE_NAME") or NOT_SET
 
         self._installers_info = installers_info
         self._installer_items = NOT_SET


### PR DESCRIPTION
## Changelog Description
Don't consider empty `AYON_BUNDLE_NAME` environment variable as defined bundle name.

## Additional info
This issue was discovered during testing of deadline jobs. GlobalPreLoadJob.py does set bundle name based on job environment variables, but if that is not filled it does fill empty string `""` and because deadline api does not support to "remove env key" (at least I didn't find it) this was the best solution. But at the end, it is not just fixing issue because of deadline, but fixing issue discovered thanks to deadline.
