### PR TITLE
Chore: Use addons details

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1420,7 +1420,8 @@ class AyonDistribution:
         """
 
         if self._addons_info is NOT_SET:
-            server_info = ayon_api.get_addons_info(details=False)
+            # Use details to get information about client.zip
+            server_info = ayon_api.get_addons_info(details=True)
             self._addons_info = server_info["addons"]
         return self._addons_info
 


### PR DESCRIPTION
## Changelog Description
Revert https://github.com/ynput/ayon-launcher/pull/130 which stopped to use details.

## Additional info
Details is important to get information about client files from server.

## Testing notes:
1. AYON launcher should update client code.
