### PR TITLE
Chore: Scripts don't rely on POETRY_HOME env variable

### DIFF
--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -112,13 +112,8 @@ function Install-Poetry() {
 
     }
 
-    $orighome = $env:POETRY_HOME
-    $origver = $env:POETRY_VERSION
     $env:POETRY_HOME=$poetry_home
-    $env:POETRY_VERSION="1.8.1"
-    (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python) -
-    $env:POETRY_HOME = $orighome
-    $env:POETRY_VERSION = $origver
+    (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python) - --version 1.8.1
 }
 
 

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -36,6 +36,7 @@ $current_dir = Get-Location
 $script_dir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $repo_root = (Get-Item $script_dir).parent.FullName
 $app_logo = "$repo_root/common/ayon_common/resources/AYON.png"
+$poetry_home = "$repo_root\.poetry"
 
 & git submodule update --init --recursive
 # Install PSWriteColor to support colorized output to terminal
@@ -111,9 +112,13 @@ function Install-Poetry() {
 
     }
 
-    $env:POETRY_HOME="$repo_root\.poetry"
+    $orighome = $env:POETRY_HOME
+    $origver = $env:POETRY_VERSION
+    $env:POETRY_HOME=$poetry_home
     $env:POETRY_VERSION="1.8.1"
     (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python) -
+    $env:POETRY_HOME = $orighome
+    $env:POETRY_VERSION = $origver
 }
 
 
@@ -266,7 +271,7 @@ function Default-Func {
 
 function Create-Env {
     Write-Color -Text ">>> ", "Reading Poetry ... " -Color Green, Gray -NoNewline
-    if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
+    if (-not (Test-Path -PathType Container -Path "$poetry_home\bin")) {
         Write-Color -Text "NOT FOUND" -Color Yellow
         Install-Poetry
         Write-Color -Text "INSTALLED" -Color Cyan
@@ -280,9 +285,9 @@ function Create-Env {
         Write-Color -Text ">>> ", "Installing virtual environment from lock." -Color Green, Gray
     }
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
-    & "$env:POETRY_HOME\bin\poetry" config virtualenvs.in-project true --local
-    & "$env:POETRY_HOME\bin\poetry" config virtualenvs.create true --local
-    & "$env:POETRY_HOME\bin\poetry" install --no-root $poetry_verbosity --ansi
+    & "$poetry_home\bin\poetry" config virtualenvs.in-project true --local
+    & "$poetry_home\bin\poetry" config virtualenvs.create true --local
+    & "$poetry_home\bin\poetry" install --no-root $poetry_verbosity --ansi
     if ($LASTEXITCODE -ne 0) {
         Write-Color -Text "!!! ", "Poetry command failed." -Color Red, Yellow
         Restore-Cwd
@@ -290,7 +295,7 @@ function Create-Env {
     }
     if (Test-Path -PathType Container -Path "$($repo_root)\.git") {
         Write-Color -Text ">>> ", "Installing pre-commit hooks ..." -Color Green, White
-        & "$env:POETRY_HOME\bin\poetry" run pre-commit install
+        & "$poetry_home\bin\poetry" run pre-commit install
         if ($LASTEXITCODE -ne 0)
         {
             Write-Color -Text "!!! ", "Installation of pre-commit hooks failed." -Color Red, Yellow
@@ -337,7 +342,7 @@ function Build-Ayon($MakeInstaller = $false) {
     Write-Color -Text ">>> ", "AYON [ ", $ayon_version, " ]" -Color Green, White, Cyan, White
 
     Write-Color -Text ">>> ", "Reading Poetry ... " -Color Green, Gray -NoNewline
-    if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
+    if (-not (Test-Path -PathType Container -Path "$($poetry_home)\bin")) {
         Write-Color -Text "NOT FOUND" -Color Yellow
         Write-Color -Text "*** ", "We need to install Poetry create virtual env first ..." -Color Yellow, Gray
         Create-Env
@@ -354,13 +359,13 @@ function Build-Ayon($MakeInstaller = $false) {
     Write-Color -Text ">>> ", "Building AYON ..." -Color Green, White
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
 
-    $FreezeContent = & "$($env:POETRY_HOME)\bin\poetry" run python -m pip --no-color freeze
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\tools\_venv_deps.py"
+    $FreezeContent = & "$($poetry_home)\bin\poetry" run python -m pip --no-color freeze
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\_venv_deps.py"
     # Make sure output is UTF-8 without BOM
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines("$($repo_root)\build\requirements.txt", $FreezeContent, $Utf8NoBomEncoding)
 
-    $out = & "$($env:POETRY_HOME)\bin\poetry" run python setup.py build 2>&1
+    $out = & "$($poetry_home)\bin\poetry" run python setup.py build 2>&1
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
     if ($LASTEXITCODE -ne 0)
     {
@@ -372,7 +377,7 @@ function Build-Ayon($MakeInstaller = $false) {
     }
 
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\tools\build_post_process.py" "build"
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\build_post_process.py" "build"
 
     if ($MakeInstaller) {
         Make-Ayon-Installer-Raw
@@ -388,12 +393,12 @@ function Build-Ayon($MakeInstaller = $false) {
 }
 
 function Installer-Post-Process() {
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\tools\installer_post_process.py" @args
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\installer_post_process.py" @args
 }
 
 function Make-Ayon-Installer-Raw() {
     Set-Content -Path "$($repo_root)\build\build.log" -Value $out
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\tools\build_post_process.py" "make-installer"
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\build_post_process.py" "make-installer"
 }
 
 function Make-Ayon-Installer() {
@@ -410,7 +415,7 @@ function Make-Ayon-Installer() {
 
 function Install-Runtime-Dependencies() {
     Write-Color -Text ">>> ", "Reading Poetry ... " -Color Green, Gray -NoNewline
-    if (-not (Test-Path -PathType Container -Path "$($env:POETRY_HOME)\bin")) {
+    if (-not (Test-Path -PathType Container -Path "$($poetry_home)\bin")) {
         Write-Color -Text "NOT FOUND" -Color Yellow
         Write-Color -Text "*** ", "We need to install Poetry create virtual env first ..." -Color Yellow, Gray
         Create-Env
@@ -418,7 +423,7 @@ function Install-Runtime-Dependencies() {
         Write-Color -Text "OK" -Color Green
     }
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\tools\runtime_dependencies.py"
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\runtime_dependencies.py"
     $endTime = [int][double]::Parse((Get-Date -UFormat %s))
     try {
         New-BurntToastNotification -AppLogo "$app_logo" -Text "AYON", "Dependencies downloaded", "All done in $( $endTime - $startTime ) secs."
@@ -426,7 +431,7 @@ function Install-Runtime-Dependencies() {
 }
 
 function Run-From-Code() {
-    & "$($env:POETRY_HOME)\bin\poetry" run python "$($repo_root)\start.py" @arguments
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\start.py" @arguments
 }
 
 function Main {
@@ -463,10 +468,6 @@ function Main {
         Write-Host "Unknown function ""$FunctionName"""
         Default-Func
     }
-}
-
-if (-not (Test-Path 'env:POETRY_HOME')) {
-    $env:POETRY_HOME = "$repo_root\.poetry"
 }
 
 # Enable if PS 7.x is needed.


### PR DESCRIPTION
## Changelog Description
Manage.ps1 and make.sh scripts do not rely on `POETRY_HOME` environment variable but always use relative path to repository.

## Additional info
The scripts did rely on the environment variable value and did set the variable only if was not set already. If there is global env variable set for user, or user have terminal which has set the env variable from different script it uses wrong path which leads to confusion and potentially broken environment.

The environment variable is set only when create-env is called to define target path, which is not possible with arguments.

## Testing notes:
1. Remove `./.poetry/` with it's content (and `./.venv/`).
2. Open terminal and set env variable `POETRY_HOME` to some random directory.
3. Run `./manage.ps1 create-env` on windows or `./make.sh create-env` on linux/macOs
4. It should install poetry to the repository instead of the path set in `POETRY_HOME`.
5. Re-open terminal and run `./manage.ps1 run` on windows or `./make.sh run` on linux/macOs.
6. It should start AYON launcher even if `POETRY_HOME` is not set.