### PR TITLE
Chore: Use 'exist_ok' when directory is created

### DIFF
--- a/common/ayon_common/connection/credentials.py
+++ b/common/ayon_common/connection/credentials.py
@@ -79,8 +79,7 @@ def get_servers_info_data():
     servers_info_path = _get_servers_path()
     if not os.path.exists(servers_info_path):
         dirpath = os.path.dirname(servers_info_path)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
+        os.makedirs(dirpath, exist_ok=True)
 
         return data
 

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -285,9 +285,7 @@ class BaseDistributionItem:
         return self._error_detail
 
     def _pre_source_process(self):
-        download_dirpath = self.download_dirpath
-        if not os.path.isdir(download_dirpath):
-            os.makedirs(download_dirpath)
+        os.makedirs(self.download_dirpath, exist_ok=True)
 
     def _receive_file(self, source_data, source_progress, downloader):
         """Receive source filepath using source data and downloader.
@@ -679,8 +677,8 @@ class InstallerDistributionItem(BaseDistributionItem):
         install_root = os.path.dirname(os.path.dirname(sys.executable))
 
         self.log.info(f"Installing AYON launcher {filepath} into:\n{install_root}")
-        if not os.path.exists(install_root):
-            os.makedirs(install_root)
+
+        os.makedirs(install_root, exist_ok=True)
 
         try:
             extract_archive_file(filepath, install_root)
@@ -839,7 +837,7 @@ class DistributionItem(BaseDistributionItem):
             shutil.rmtree(unzip_dirpath)
 
         # Create directory
-        os.makedirs(unzip_dirpath)
+        os.makedirs(unzip_dirpath, exist_ok=True)
 
     def _post_source_process(
         self, filepath, source_data, source_progress, downloader
@@ -1731,12 +1729,9 @@ class AyonDistribution:
         Args:
             filepath (str): Path to json file.
             data (Union[Dict[str, Any], List[Any]]): Data to store into file.
-        """
 
-        if not os.path.exists(filepath):
-            dirpath = os.path.dirname(filepath)
-            if not os.path.exists(dirpath):
-                os.makedirs(dirpath)
+        """
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
         with open(filepath, "w") as stream:
             json.dump(data, stream, indent=4)
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -20,11 +20,7 @@ def get_local_dir(*subdirs):
         raise ValueError("Must fill dir_name if nothing else provided!")
 
     local_dir = get_ayon_appdirs(*subdirs)
-    if not os.path.isdir(local_dir):
-        try:
-            os.makedirs(local_dir)
-        except Exception:  # TODO fix exception
-            raise RuntimeError(f"Cannot create {local_dir}")
+    os.makedirs(local_dir, exist_ok=True)
 
     return local_dir
 

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -96,9 +96,7 @@ def get_local_site_id():
             site_id = stream.read()
 
     if not site_id:
-        folder_path = os.path.dirname(site_id_path)
-        if not os.path.exists(folder_path):
-            os.makedirs(folder_path)
+        os.makedirs(os.path.dirname(site_id_path), exist_ok=True)
         site_id = _create_local_site_id()
         with open(site_id_path, "w") as stream:
             stream.write(site_id)
@@ -177,12 +175,10 @@ def store_executables_info(info):
     """Store information about executables.
 
     This will override existing information so use it wisely.
-    """
 
+    """
     filepath = get_executables_info_filepath()
-    dirpath = os.path.dirname(filepath)
-    if not os.path.exists(dirpath):
-        os.makedirs(dirpath)
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
     with open(filepath, "w") as stream:
         json.dump(info, stream, indent=4)


### PR DESCRIPTION
## Changelog Description
Use `exist_ok=True` when `os.makedirs` is called.

## Additional info
Simplifies the code and also makes it more safe.

## Testing notes:
1. AYON launcher is capable of creating all folders that are necessary to be created.
