### PR TITLE
Chore: Add distro and pyside2 information to installer filename

### DIFF
--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 import blessed
 import enlighten
+import distro
 
 term = blessed.Terminal()
 manager = enlighten.get_manager()
@@ -582,10 +583,15 @@ def store_base_metadata(build_root, build_content_root, ayon_version):
         build_content_root (Path): Path build content directory.
         ayon_version (str): AYON version.
     """
+    platform_name = platform.system().lower()
 
+    os_distro = None
+    if platform_name == "linux":
+        os_distro = f"{distro.id()}{distro.major_version()}"
     metadata = {
         "version": ayon_version,
-        "platform": platform.system().lower(),
+        "platform": platform_name,
+        "distro": os_distro,
         "python_version": platform.python_version(),
         "python_modules": get_packages_info(build_root),
         "runtime_python_modules": get_runtime_modules(build_content_root),
@@ -649,7 +655,9 @@ def _create_windows_installer(
     _build_root,
     installer_root,
     build_content_root,
-    ayon_version
+    ayon_version,
+    os_distro,
+    pyside2_used,
 ):
     """Create Windows installer.
 
@@ -657,11 +665,12 @@ def _create_windows_installer(
         Path: Path to installer file.
     """
 
+    pyside2_suffix = "-pyside2" if pyside2_used else ""
     iscc_executable = _find_iscc()
 
     inno_setup_path = ayon_root / "inno_setup.iss"
     env = os.environ.copy()
-    installer_basename = f"AYON-{ayon_version}-win-setup"
+    installer_basename = f"AYON-{ayon_version}-win{pyside2_suffix}-setup"
 
     env["BUILD_SRC_DIR"] = str(build_content_root.relative_to(ayon_root))
     env["BUILD_DST_DIR"] = str(installer_root.relative_to(ayon_root))
@@ -679,15 +688,18 @@ def _create_linux_installer(
     _build_root,
     installer_root,
     build_content_root,
-    ayon_version
+    ayon_version,
+    os_distro,
+    pyside2_used,
 ):
     """Linux installer is just tar file.
 
     Returns:
         Path: Path to installer file.
-    """
 
-    basename = f"AYON-{ayon_version}-linux"
+    """
+    pyside2_suffix = "-pyside2" if pyside2_used else ""
+    basename = f"AYON-{ayon_version}-linux-{os_distro}{pyside2_suffix}"
     filename = f"{basename}.tar.gz"
     output_path = installer_root / filename
 
@@ -701,7 +713,13 @@ def _create_linux_installer(
 
 
 def _create_darwin_installer(
-    _ayon_root, build_root, installer_root, _build_content_root, ayon_version
+    _ayon_root,
+    build_root,
+    installer_root,
+    _build_content_root,
+    ayon_version,
+    _os_distro,
+    pyside2_used,
 ):
     """Create MacOS installer (.dmg).
 
@@ -710,10 +728,12 @@ def _create_darwin_installer(
 
     Raises:
         ValueError: If 'create-dmg' is not available.
-    """
 
+    """
+    pyside2_suffix = "-pyside2" if pyside2_used else ""
     app_filepath = _get_darwin_output_path(build_root, ayon_version)
-    output_path = installer_root / f"AYON-{ayon_version}-macos.dmg"
+    filename = f"AYON-{ayon_version}-macos{pyside2_suffix}.dmg"
+    output_path = installer_root / filename
     # TODO check if 'create-dmg' is available
     try:
         subprocess.call(["create-dmg"])
@@ -785,6 +805,8 @@ def store_installer_metadata(build_root, installer_root, installer_path):
 def create_installer(ayon_root, build_root):
     metadata = get_build_metadata(build_root)
     ayon_version = metadata["version"]
+    os_distro = metadata["distro"]
+    pyside2_used = "PySide2" in metadata["runtime_python_modules"]
     build_content_root = get_build_content_root(build_root, ayon_version)
     installer_root = build_root / "installer"
     if installer_root.exists():
@@ -796,7 +818,9 @@ def create_installer(ayon_root, build_root):
         build_root,
         installer_root,
         build_content_root,
-        ayon_version
+        ayon_version,
+        os_distro,
+        pyside2_used,
     )
     store_installer_metadata(
         build_root, installer_root, str(installer_path.absolute())

--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -588,13 +588,13 @@ def store_base_metadata(build_root, build_content_root, ayon_version):
     """
     platform_name = platform.system().lower()
 
-    os_distro = None
+    distro_short = None
     if platform_name == "linux":
-        os_distro = f"{distro.id()}{distro.major_version()}"
+        distro_short = f"{distro.id()}{distro.major_version()}"
     metadata = {
         "version": ayon_version,
         "platform": platform_name,
-        "distro": os_distro,
+        "distro_short": distro_short,
         "python_version": platform.python_version(),
         "python_modules": get_packages_info(build_root),
         "runtime_python_modules": get_runtime_modules(build_content_root),
@@ -659,7 +659,7 @@ def _create_windows_installer(
     installer_root,
     build_content_root,
     ayon_version,
-    os_distro,
+    _distro_short,
     pyside2_used,
 ):
     """Create Windows installer.
@@ -692,7 +692,7 @@ def _create_linux_installer(
     installer_root,
     build_content_root,
     ayon_version,
-    os_distro,
+    distro_short,
     pyside2_used,
 ):
     """Linux installer is just tar file.
@@ -702,7 +702,7 @@ def _create_linux_installer(
 
     """
     pyside2_suffix = "-pyside2" if pyside2_used else ""
-    basename = f"AYON-{ayon_version}-linux-{os_distro}{pyside2_suffix}"
+    basename = f"AYON-{ayon_version}-linux-{distro_short}{pyside2_suffix}"
     filename = f"{basename}.tar.gz"
     output_path = installer_root / filename
 
@@ -721,7 +721,7 @@ def _create_darwin_installer(
     installer_root,
     _build_content_root,
     ayon_version,
-    _os_distro,
+    _distro_short,
     pyside2_used,
 ):
     """Create MacOS installer (.dmg).
@@ -808,7 +808,7 @@ def store_installer_metadata(build_root, installer_root, installer_path):
 def create_installer(ayon_root, build_root):
     metadata = get_build_metadata(build_root)
     ayon_version = metadata["version"]
-    os_distro = metadata["distro"]
+    distro_short = metadata["distro_short"]
     pyside2_used = "PySide2" in metadata["runtime_python_modules"]
     build_content_root = get_build_content_root(build_root, ayon_version)
     installer_root = build_root / "installer"
@@ -822,7 +822,7 @@ def create_installer(ayon_root, build_root):
         installer_root,
         build_content_root,
         ayon_version,
-        os_distro,
+        distro_short,
         pyside2_used,
     )
     store_installer_metadata(

--- a/tools/build_post_process.py
+++ b/tools/build_post_process.py
@@ -35,7 +35,10 @@ from pathlib import Path
 
 import blessed
 import enlighten
-import distro
+if platform.system().lower() == "linux":
+    import distro
+else:
+    distro = None
 
 term = blessed.Terminal()
 manager = enlighten.get_manager()

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -434,6 +434,7 @@ default_help() {
   echo "  create-server-package         Create package ready for AYON server"
   echo "  run                           Run desktop application from code"
   echo "  docker-build [variant]        Build AYON using Docker. Variant can be 'debian', 'rocky8' or 'rocky9'"
+  echo "      --use-pyside2                 Use PySide2 instead of PySide6."
   echo ""
 }
 

--- a/tools/make.sh
+++ b/tools/make.sh
@@ -228,7 +228,7 @@ install_runtime_dependencies () {
   pushd "$repo_root" > /dev/null || return > /dev/null
 
   echo -e "${BIGreen}>>>${RST} Installing runtime dependencies ..."
-  "$poetry_home_root/bin/poetry" run python "$repo_root/tools/runtime_dependencies.py"
+  "$poetry_home_root/bin/poetry" run python "$repo_root/tools/runtime_dependencies.py" "$@"
 }
 
 fix_macos_build () {
@@ -426,6 +426,7 @@ default_help() {
   echo "Runtime targets:"
   echo "  create-env                    Install Poetry and update venv by lock file"
   echo "  install-runtime-dependencies  Install runtime dependencies (Qt binding)"
+  echo "      --use-pyside2                 Install PySide2 instead of PySide6."
   echo "  install-runtime               Alias for 'install-runtime-dependencies'"
   echo "  build                         Build desktop application"
   echo "  make-installer                Make desktop application installer"
@@ -454,7 +455,7 @@ main() {
       exit $return_code
       ;;
     "installruntimedependencies"|"installruntime")
-      install_runtime_dependencies || return_code=$?
+      install_runtime_dependencies "${@:2}" || return_code=$?
       exit $return_code
       ;;
     "build"|"buildayon")

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -259,6 +259,7 @@ function Default-Func {
     Write-Host "Runtime targets:"
     Write-Color -text "  create-env                    ", "Install Poetry and update venv by lock file" -Color White, Cyan
     Write-Color -text "  install-runtime-dependencies  ", "Install runtime dependencies (Qt binding)" -Color White, Cyan
+    Write-Color -text "      --use-pyside2                 Install ", "PySide2", " instead of ", "PySide6", "." -Color White, Cyan, White, Cyan, White
     Write-Color -text "  install-runtime               ", "Alias for '", "install-runtime-dependencies", "'" -Color White, Cyan, White, Cyan
     Write-Color -text "  build                         ", "Build desktop application" -Color White, Cyan
     Write-Color -text "  make-installer                ", "Make desktop application installer" -Color White, Cyan
@@ -463,7 +464,7 @@ function Install-Runtime-Dependencies() {
         Write-Color -Text "OK" -Color Green
     }
     $startTime = [int][double]::Parse((Get-Date -UFormat %s))
-    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\runtime_dependencies.py"
+    & "$($poetry_home)\bin\poetry" run python "$($repo_root)\tools\runtime_dependencies.py" @args
     $endTime = [int][double]::Parse((Get-Date -UFormat %s))
     try {
         New-BurntToastNotification -AppLogo "$app_logo" -Text "AYON", "Dependencies downloaded", "All done in $( $endTime - $startTime ) secs."
@@ -486,7 +487,7 @@ function Main {
     } elseif ($FunctionName -eq "createenv") {
         Create-Env
     } elseif (($FunctionName -eq "installruntimedependencies") -or ($FunctionName -eq "installruntime")) {
-        Install-Runtime-Dependencies
+        Install-Runtime-Dependencies @arguments
     } elseif ($FunctionName -eq "build") {
         Build-Ayon
     } elseif ($FunctionName -eq "makeinstaller") {

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -266,6 +266,7 @@ function Default-Func {
     Write-Color -text "  upload                        ", "Upload installer to server" -Color White, Cyan
     Write-Color -text "  run                           ", "Run desktop application from code" -Color White, Cyan
     Write-Color -text "  docker-build ","[variant]        ", "Build AYON using Docker. Variant can be '", "ubuntu", "', '", "debian", "', '", "rocky8", "' or '", "rocky9", "'" -Color White, Yellow, Cyan, Yellow, Cyan, Yellow, Cyan, Yellow, Cyan, Yellow, Cyan
+    Write-Color -text "      --use-pyside2                 Use ", "PySide2", " instead of ", "PySide6", "." -Color White, Cyan, White, Cyan, White
     Write-Host ""
 }
 


### PR DESCRIPTION
## Changelog Description
Installer filename contains information about used pyside2 and on linux also contains distribution short .

## Additional info
It is PITA to find out for which distribution was laucher created and if was created with pyside2 or pyside6, this should help a little. Server still does support only one linux installer, but at least we're able to find out which is used.

## Testing notes:
1. Create linux installer.
2. Filename should automatically contain distro name.
3. If `--use-pyside2` is used, the filename also contains `-pyside2`.

Resolves https://github.com/ynput/ayon-launcher/issues/128