### PR TITLE
🧊 freeze pip to version still supporting python 3.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1498,6 +1498,17 @@ files = [
 test = ["importlib-metadata", "pytest"]
 
 [[package]]
+name = "pip"
+version = "24.0"
+description = "The PyPA recommended tool for installing Python packages."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pip-24.0-py3-none-any.whl", hash = "sha256:ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc"},
+    {file = "pip-24.0.tar.gz", hash = "sha256:ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "3.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -2375,4 +2386,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.1,<3.10"
-content-hash = "feaf6baa335c38b8074eeb52a577cbfee0cf7cd4473a00a403ec698aee6e3947"
+content-hash = "13c774f6fa732fca441e529f8b502a8c7de211d665c84ba1ef310e96f4472989"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ QtPy = "^2.3.0"
 pywin32 = { version = "301", markers = "sys_platform == 'win32'" }
 python3-xlib = { version="*", markers = "sys_platform == 'linux'"}
 distro = { version="^1.9.0", markers = "sys_platform == 'linux'"}
+pip = "24.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^6.0"


### PR DESCRIPTION
## Changelog Description
pip 24.1 dropped support for Python 3.7. This PR is freezing pip to 24.0. 

## Additional info
Pip is used when installing/querying packages like if pyside2/6 is installed.

## Testing notes:
Re-create situation, where Python 3.7 based host tries to install pyside in their pre-launch hooks.
