### PR TITLE
Chore: Installing of new AYON launcher makes sure windows registry is set

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -910,12 +910,20 @@ def _deploy_shim_macos(installer_shim_root):
             subprocess.run(["hdiutil", "detach", hdi_mounted_volume])
 
 
-def deploy_ayon_launcher_shims(create_desktop_icons=False):
+def deploy_ayon_launcher_shims(
+    create_desktop_icons=False,
+    validate_windows_registers=False,
+):
     """Deploy shim executables for AYON launcher.
+
+    Argument 'validate_registers' is to fix registered protocol on Windows,
+        issue caused in v1.1.0, since 1.1.1 is used different registry path.
 
     Args:
         create_desktop_icons (Optional[bool]): Create desktop shortcuts. Used
             only on windows.
+        validate_windows_registers (Optional[bool]): Validate if protocol is
+            registered on windows.
 
     """
     if not IS_BUILT_APPLICATION:
@@ -939,6 +947,9 @@ def deploy_ayon_launcher_shims(create_desktop_icons=False):
 
     # Skip if shim is same or lower
     if src_shim_version <= semver.VersionInfo.parse(dst_shim_version):
+        # Make sure windows registers are correctly set for each user
+        if validate_windows_registers:
+            register_windows_launcher_protocol()
         return
 
     platform_name = platform.system().lower()

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -727,23 +727,23 @@ def validate_file_checksum(
 
 # --- SHIM information ---
 # Helpers to resolve registering shim as 'ayon-launcher' protocol handler
-def _is_windows_launcher_protocol_registered():
+def _is_windows_launcher_protocol_registered() -> bool:
     from ._windows_register_scheme import is_reg_set
 
     return is_reg_set(get_shim_executable_path())
 
 
-def _register_windows_launcher_protocol():
+def _register_windows_launcher_protocol() -> bool:
     from ._windows_register_scheme import set_reg
 
     return set_reg(get_shim_executable_path())
 
 
-def _get_linux_desktop_file_path():
+def _get_linux_desktop_file_path() -> str:
     return os.path.expanduser("~/.local/share/applications/ayon.desktop")
 
 
-def _get_linux_desktop_executable_content():
+def _get_linux_desktop_executable_content() -> str:
     dst_desktop_executable = _get_linux_desktop_file_path()
     executable_root = _get_shim_executable_root()
 
@@ -758,7 +758,7 @@ def _get_linux_desktop_executable_content():
     return content
 
 
-def _is_launcher_launcher_protocol_registered():
+def _is_launcher_launcher_protocol_registered() -> bool:
     # Add 'ayon.desktop' to applications
     desktop_file_path = _get_linux_desktop_file_path()
     # Skip if applications directory does not exist
@@ -773,7 +773,7 @@ def _is_launcher_launcher_protocol_registered():
     return old_content == new_content
 
 
-def _register_linux_launcher_protocol():
+def _register_linux_launcher_protocol() -> bool:
     # Add 'ayon.desktop' to applications
     dst_desktop_file_path = _get_linux_desktop_file_path()
     desktop_filename, apps_dir = os.path.split(dst_desktop_file_path)
@@ -817,7 +817,7 @@ def _register_linux_launcher_protocol():
     return True
 
 
-def is_ayon_launcher_protocol_registered():
+def is_ayon_launcher_protocol_registered() -> bool:
     platform_name = platform.system().lower()
     if platform_name == "windows":
         return _is_windows_launcher_protocol_registered()
@@ -827,7 +827,7 @@ def is_ayon_launcher_protocol_registered():
     return os.path.exists(get_shim_executable_path())
 
 
-def register_ayon_launcher_protocol():
+def register_ayon_launcher_protocol() -> bool:
     platform_name = platform.system().lower()
     if platform_name == "windows":
         return _register_windows_launcher_protocol()
@@ -837,7 +837,7 @@ def register_ayon_launcher_protocol():
     return True
 
 
-def _get_shim_executable_root():
+def _get_shim_executable_root() -> str:
     """Root to shim executable.
 
     Returns:
@@ -850,7 +850,7 @@ def _get_shim_executable_root():
     return "/Applications/AYON.app/Contents/MacOS"
 
 
-def get_shim_executable_path():
+def get_shim_executable_path() -> str:
     """Path to shim executable.
 
     It is not validated if shim exists.
@@ -865,7 +865,7 @@ def get_shim_executable_path():
     return os.path.join(_get_shim_executable_root(), filename)
 
 
-def _get_installed_shim_version():
+def _get_installed_shim_version() -> str:
     """Get installed shim version.
 
     Returns:
@@ -885,7 +885,10 @@ def _get_installed_shim_version():
     return dst_shim_version
 
 
-def _deploy_shim_windows(installer_shim_root, create_desktop_icons):
+def _deploy_shim_windows(
+    installer_shim_root: str,
+    create_desktop_icons: bool
+) -> bool:
     """Deploy shim executable on Windows.
 
     Windows shim is deployed using exe installer.
@@ -911,7 +914,7 @@ def _deploy_shim_windows(installer_shim_root, create_desktop_icons):
     return code == 0
 
 
-def _deploy_shim_linux(installer_shim_root):
+def _deploy_shim_linux(installer_shim_root: str) -> bool:
     """Deploy shim executable on Linux.
 
     Linux shim is deployed using zip file exported to appdirs.
@@ -929,7 +932,7 @@ def _deploy_shim_linux(installer_shim_root):
     return True
 
 
-def _deploy_shim_macos(installer_shim_root):
+def _deploy_shim_macos(installer_shim_root: str):
     """Deploy shim executable on macOS.
 
     MacOS shim is deployed using dmg file exported to '/Applications'.
@@ -975,8 +978,8 @@ def _deploy_shim_macos(installer_shim_root):
 
 
 def deploy_ayon_launcher_shims(
-    create_desktop_icons=False,
-    ensure_protocol_is_registered=False,
+    create_desktop_icons: Optional[bool] = False,
+    ensure_protocol_is_registered: Optional[bool] = False,
 ):
     """Deploy shim executables for AYON launcher.
 

--- a/start.py
+++ b/start.py
@@ -648,7 +648,7 @@ def _start_distribution():
     os.environ["PYTHONPATH"] = os.pathsep.join(python_paths)
 
 
-def init_launcher_executable(validate_windows_registers=False):
+def init_launcher_executable(ensure_protocol_is_registered=False):
     """Initialize AYON launcher executable.
 
     Make sure current AYON launcher executable is stored to known executables
@@ -659,7 +659,7 @@ def init_launcher_executable(validate_windows_registers=False):
     store_current_executable_info()
     deploy_ayon_launcher_shims(
         create_desktop_icons=create_desktop_icons,
-        validate_windows_registers=validate_windows_registers,
+        ensure_protocol_is_registered=ensure_protocol_is_registered,
     )
 
 
@@ -1011,7 +1011,7 @@ def get_info(use_staging=None, use_dev=None) -> list:
 def main():
     # AYON launcher was started to initialize itself
     if "init-ayon-launcher" in sys.argv:
-        init_launcher_executable(validate_windows_registers=True)
+        init_launcher_executable(ensure_protocol_is_registered=True)
         sys.exit(0)
 
     if SHOW_LOGIN_UI:

--- a/start.py
+++ b/start.py
@@ -648,7 +648,7 @@ def _start_distribution():
     os.environ["PYTHONPATH"] = os.pathsep.join(python_paths)
 
 
-def init_launcher_executable():
+def init_launcher_executable(validate_windows_registers=False):
     """Initialize AYON launcher executable.
 
     Make sure current AYON launcher executable is stored to known executables
@@ -657,7 +657,10 @@ def init_launcher_executable():
     """
     create_desktop_icons = "--create-desktop-icons" in sys.argv
     store_current_executable_info()
-    deploy_ayon_launcher_shims(create_desktop_icons=create_desktop_icons)
+    deploy_ayon_launcher_shims(
+        create_desktop_icons=create_desktop_icons,
+        validate_windows_registers=validate_windows_registers,
+    )
 
 
 def fill_pythonpath():
@@ -1008,7 +1011,7 @@ def get_info(use_staging=None, use_dev=None) -> list:
 def main():
     # AYON launcher was started to initialize itself
     if "init-ayon-launcher" in sys.argv:
-        init_launcher_executable()
+        init_launcher_executable(validate_windows_registers=True)
         sys.exit(0)
 
     if SHOW_LOGIN_UI:


### PR DESCRIPTION
## Changelog Description
Make sure that windows registry is set to new registry path on update.

## Additional info
Windows registry are not updated if shim is already deployed, changes in this PR makes sure windows registry are updated on launcher update.

## Testing notes:
1. Checkout this branch and build AYON launcher.
2. Install 1.1.0 AYON launcher and confirm admin privileges -> that should install shim and register protocol.
3. Install launcher from this branch.
4. When installation is finished, registry `HKEY_CURRENT_USER\SOFTWARE\Classes\ayon-launcher` should be set.