### PR TITLE
Chore: Safe distribution

### DIFF
--- a/common/ayon_common/distribution/__init__.py
+++ b/common/ayon_common/distribution/__init__.py
@@ -4,6 +4,7 @@ from .exceptions import (
 )
 from .control import AyonDistribution
 from .utils import (
+    show_missing_permissions,
     show_missing_bundle_information,
     show_installer_issue_information,
     UpdateWindowManager,
@@ -16,6 +17,7 @@ __all__ = (
 
     "AyonDistribution",
 
+    "show_missing_permissions",
     "show_missing_bundle_information",
     "show_installer_issue_information",
     "UpdateWindowManager",

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1385,7 +1385,8 @@ class AyonDistribution:
             self._installer_dist_error = (
                 "Your user does not have required permissions to update"
                 " AYON launcher."
-                " Please contact your admin or use user with permissions."
+                " Please contact your administrator, or use user"
+                " with permissions."
             )
             return
 

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1381,15 +1381,6 @@ class AyonDistribution:
             )
             return
 
-        if installer_item.is_missing_permissions:
-            self._installer_dist_error = (
-                "Your user does not have required permissions to update"
-                " AYON launcher."
-                " Please contact your administrator, or use user"
-                " with permissions."
-            )
-            return
-
         downloader_data = {
             "type": "installer",
             "version": installer_item.version,
@@ -1415,6 +1406,15 @@ class AyonDistribution:
                 downloader_data,
                 f"Installer {installer_item.version}"
             )
+            if dist_item.is_missing_permissions:
+                self._installer_dist_error = (
+                    "Your user does not have required permissions to update"
+                    " AYON launcher."
+                    " Please contact your administrator, or use user"
+                    " with permissions."
+                )
+                return
+
             dist_item.distribute()
             self._installer_executable = dist_item.executable
             if dist_item.installer_error is not None:

--- a/common/ayon_common/distribution/ui/distribution_error.py
+++ b/common/ayon_common/distribution/ui/distribution_error.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import json
 

--- a/common/ayon_common/distribution/ui/distribution_error.py
+++ b/common/ayon_common/distribution/ui/distribution_error.py
@@ -43,6 +43,7 @@ class MessageWindow(QtWidgets.QDialog):
         sub_message_label = None
         if sub_message:
             sub_message_label = QtWidgets.QLabel(sub_message, info_widget)
+            sub_message_label.setWordWrap(True)
 
         info_layout = QtWidgets.QVBoxLayout(info_widget)
         info_layout.setContentsMargins(0, 0, 0, 0)

--- a/common/ayon_common/distribution/ui/distribution_error.py
+++ b/common/ayon_common/distribution/ui/distribution_error.py
@@ -16,14 +16,14 @@ class MessageWindow(QtWidgets.QDialog):
     default_height = 170
 
     def __init__(
-        self, message, installer_path, parent=None
+        self, title, message, sub_message, parent=None
     ):
         super().__init__(parent)
 
         icon_path = get_icon_path()
         icon = QtGui.QIcon(icon_path)
         self.setWindowIcon(icon)
-        self.setWindowTitle("AYON-launcher distribution")
+        self.setWindowTitle(title)
 
         self._first_show = True
 
@@ -40,22 +40,16 @@ class MessageWindow(QtWidgets.QDialog):
         info_label = QtWidgets.QLabel(message, info_widget)
         info_label.setWordWrap(True)
 
-        installer_path_label = None
-        if installer_path and os.path.exists(installer_path):
-            installer_path_label = QtWidgets.QLabel(
-                (
-                    "NOTE: Install file can be found here:"
-                    f"<br/><b>{installer_path}</b>"
-                ),
-                info_widget
-            )
+        sub_message_label = None
+        if sub_message:
+            sub_message_label = QtWidgets.QLabel(sub_message, info_widget)
 
         info_layout = QtWidgets.QVBoxLayout(info_widget)
         info_layout.setContentsMargins(0, 0, 0, 0)
         info_layout.addWidget(info_label, 0)
         info_layout.addStretch(1)
-        if installer_path_label:
-            info_layout.addWidget(installer_path_label, 0)
+        if sub_message_label:
+            info_layout.addWidget(sub_message_label, 0)
 
         body_layout = QtWidgets.QHBoxLayout(body_widget)
         body_layout.setContentsMargins(0, 0, 0, 0)
@@ -126,7 +120,11 @@ def main():
         data = json.load(stream)
 
     app = get_qt_app()
-    window = MessageWindow(data["message"], data["installer_path"])
+    window = MessageWindow(
+        data["title"],
+        data["message"],
+        data["sub_message"],
+    )
     window.show()
     app.exec_()
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -50,6 +50,10 @@ def get_dependencies_dir():
     return dependencies_dir
 
 
+def show_missing_permissions():
+    print("TODO implement 'show_missing_permissions' function")
+
+
 def show_missing_bundle_information(url, bundle_name=None, username=None):
     """Show missing bundle information window.
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -56,7 +56,7 @@ def show_missing_permissions():
         "AYON distribution - Permissions issues",
         (
             "Your user does not have permissions to distribute updates."
-            "<br/><br/>Please contact your system administrator, or use user"
+            "<br/><br/>Please contact your administrator, or use user"
             " with permissions to distribute addons and dependency package."
         ),
     )

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import subprocess
 import tempfile
+from typing import Optional
 
 from ayon_common.utils import get_launcher_storage_dir, get_ayon_launch_args
 
@@ -90,18 +91,40 @@ def show_installer_issue_information(message, installer_path=None):
         message (str): Error message with description of an issue.
         installer_path (Optional[str]): Path to installer file so user can
             try to install it manually.
+
     """
+    sub_message = None
+    if installer_path and os.path.exists(installer_path):
+        sub_message = (
+            "NOTE: Install file can be found here:"
+            f"<br/><b>{installer_path}</b>"
+        )
+    _show_message_dialog(
+        "AYON-launcher distribution",
+        message,
+        sub_message,
+    )
 
+
+def _show_message_dialog(
+    title: str,
+    message: str,
+    sub_message: Optional[str] = None,
+):
     ui_dir = os.path.join(os.path.dirname(__file__), "ui")
-    script_path = os.path.join(ui_dir, "installer_distribution_error.py")
-
+    script_path = os.path.join(ui_dir, "distribution_error.py")
     with tempfile.NamedTemporaryFile(
         suffix=".json", delete=False
     ) as tmp:
         filepath = tmp.name
+
     with open(filepath, "w") as stream:
         json.dump(
-            {"message": message, "installer_path": installer_path},
+            {
+                "title": title,
+                "message": message,
+                "sub_message": sub_message,
+            },
             stream
         )
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -54,11 +54,10 @@ def get_dependencies_dir():
 def show_missing_permissions():
     _show_message_dialog(
         "AYON distribution - Permissions issues",
-        "Your user does not have permissions to distribute updates.",
         (
-            "Please contact your system administrator, or use user with"
-            " permissions to distribute AYON addons and"
-            " dependency package."
+            "Your user does not have permissions to distribute updates."
+            "<br/><br/>Please contact your system administrator, or use user"
+            " with permissions to distribute addons and dependency package."
         ),
     )
 

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -52,7 +52,15 @@ def get_dependencies_dir():
 
 
 def show_missing_permissions():
-    print("TODO implement 'show_missing_permissions' function")
+    _show_message_dialog(
+        "AYON distribution - Permissions issues",
+        "Your user does not have permissions to distribute updates.",
+        (
+            "Please contact your system administrator, or use user with"
+            " permissions to distribute AYON addons and"
+            " dependency package."
+        ),
+    )
 
 
 def show_missing_bundle_information(url, bundle_name=None, username=None):

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -98,7 +98,7 @@ def get_launcher_storage_dir(
         os.environ["AYON_LAUNCHER_STORAGE_DIR"] = storage_dir
 
     path = os.path.join(storage_dir, *subdirs)
-    if create:
+    if create and not os.path.exists(path):
         os.makedirs(path, exist_ok=True)
     return path
 

--- a/start.py
+++ b/start.py
@@ -333,6 +333,7 @@ from ayon_common.distribution import (  # noqa E402
     AyonDistribution,
     BundleNotFoundError,
     show_missing_bundle_information,
+    show_missing_permissions,
     show_installer_issue_information,
     UpdateWindowManager,
 )
@@ -541,9 +542,19 @@ def _start_distribution():
     """
 
     # Create distribution object
-    distribution = AyonDistribution(
-        skip_installer_dist=not IS_BUILT_APPLICATION
-    )
+    try:
+        distribution = AyonDistribution(
+            skip_installer_dist=not IS_BUILT_APPLICATION
+        )
+    except PermissionError:
+        _print(
+            "!!! Failed to initialize distribution"
+            " because of permissions error."
+        )
+        if not HEADLESS_MODE_ENABLED:
+            show_missing_permissions()
+        sys.exit(1)
+
     bundle = None
     bundle_name = None
     # Try to find required bundle and handle missing one

--- a/start.py
+++ b/start.py
@@ -607,6 +607,10 @@ def _start_distribution():
     )
     _run_disk_mapping(bundle_name)
 
+    if distribution.is_missing_permissions:
+        show_missing_permissions()
+        sys.exit(1)
+
     # Start distribution
     update_window_manager = UpdateWindowManager()
     if not HEADLESS_MODE_ENABLED:


### PR DESCRIPTION
## Changelog Description
Modified distribution to be able to handle missing permissions in destination directory. A dialog is shown if user does not have permissions to distribute installer, addons or dependency package. If everything is available, then it just uses it.

## Additional info
Make sure that folders are not created if they already do exist, because it can trigger `PermissionsError`.

## Testing notes:
Windows should not be affected at all.

## General setup
1. Create a directory with read permissions for other users (e.g. `/usr/share/ayon`).
2. Create "artist" user (you have to set password to the user).

### Addons and dependency package distribution
1. Open terminal and use the user (`su - artist`)
2. Set env variable `AYON_LAUNCHER_STORAGE_DIR` to dir from `General setup 1`.
3. Start AYON launcher with changes from this PR.
4. It should show dialog that you don't have permissions.
5. As sudo: Start AYON launcher with user that have permissions to the directory -> it should distribute updates.
6. Start AYON launcher as artist, it should start just fine.

### AYON launcher update
1. Create subdir `app` and export ayon launcher to the directory (e.g. `/usr/share/ayon/app/ayon-launcher-rocky9-1.1.1+dev`).
2. Change production to bundle that uses other version of ayon launcher.
3. Open terminal and use the user (`su - artist`)
4. Set env variable `AYON_LAUNCHER_STORAGE_DIR` to dir from `General setup 1`.
5. Start AYON launcher.
6. It should report that you don't have permissions to update AYON launcher.

I don't know what would happen if the AYON launcher version would be installed by user with permissions. I think it would still report permissions issue for the other user as launcher information are stored per user. Please try out and report.

Resolves https://github.com/ynput/ayon-launcher/issues/198