### PR TITLE
Chore: Use poetry dev group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2507,4 +2507,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.1,<3.10"
-content-hash = "be753d04333492fced945faff75134ab5970b632a7b0de619f26c74dd52d774e"
+content-hash = "06791f718e99852447719de59e1edfaa9b820997824e93e7ff4222bde5f3cb06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ python3-xlib = { version="*", markers = "sys_platform == 'linux'"}
 distro = { version="^1.9.0", markers = "sys_platform == 'linux'"}
 pip = "24.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^6.0"
 autopep8 = "^2.0"
 coverage = "*"

--- a/shim/poetry.lock
+++ b/shim/poetry.lock
@@ -224,4 +224,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.1,<3.10"
-content-hash = "e40c8f3cf81199a7397d485687b69aaedc7c35a0324803eb96b38697dfd8c8b9"
+content-hash = "39880cae4ab13117b418f3156fd97e2fe2e72b6ec470ce2b48184dbb4f0aa591"

--- a/shim/pyproject.toml
+++ b/shim/pyproject.toml
@@ -20,7 +20,7 @@ python = ">=3.9.1,<3.10"
 platformdirs = "^3.0.0"
 semver = "^2.13.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 cx_freeze = "6.15.16"
 
 [tool.poetry.urls]


### PR DESCRIPTION
## Changelog Description
Use `tool.poetry.group.dev.dependencies` instead of `tool.poetry.dev-dependencies`.

## Additional info
Group `tool.poetry.dev-dependencies` is being deprecated.
