### PR TITLE
Chore: Use dataclasses in distribution logic

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1612,7 +1612,7 @@ class AyonDistribution:
             # Dev mode can redirect addon directory elsewhere
             if self.use_dev:
                 dev_addon_info = dev_addons.get(addon_name)
-                if dev_addon_info is None or dev_addon_info.enabled is True:
+                if dev_addon_info is not None and dev_addon_info.enabled:
                     continue
 
             addon_version = addon_versions.get(addon_name)

--- a/common/ayon_common/distribution/downloaders.py
+++ b/common/ayon_common/distribution/downloaders.py
@@ -2,6 +2,7 @@ import os
 import logging
 import platform
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
 import ayon_api
 
@@ -18,7 +19,13 @@ class SourceDownloader(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def download(cls, source, destination_dir, data, transfer_progress):
+    def download(
+        cls,
+        source: dict[str, Any],
+        destination_dir: str,
+        data: dict[str, Any],
+        transfer_progress: ayon_api.TransferProgress,
+    ):
         """Returns url of downloaded addon zip file.
 
         Tranfer progress can be ignored, in that case file transfer won't
@@ -41,7 +48,12 @@ class SourceDownloader(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def cleanup(cls, source, destination_dir, data):
+    def cleanup(
+        cls,
+        source: dict[str, Any],
+        destination_dir: str,
+        data: dict[str, Any]
+    ):
         """Cleanup files when distribution finishes or crashes.
 
         Cleanup e.g. temporary files (downloaded zip) or other related stuff
@@ -51,7 +63,12 @@ class SourceDownloader(metaclass=ABCMeta):
         pass
 
     @classmethod
-    def check_hash(cls, filepath, checksum, checksum_algorithm="sha256"):
+    def check_hash(
+        cls,
+        filepath: str,
+        checksum: str,
+        checksum_algorithm: str="sha256",
+    ):
         """Compares 'hash' of downloaded 'addon_url' file.
 
         Args:
@@ -67,7 +84,7 @@ class SourceDownloader(metaclass=ABCMeta):
             raise ValueError(f"{filepath} doesn't match expected hash.")
 
     @classmethod
-    def unzip(cls, filepath, destination_dir):
+    def unzip(cls, filepath: str, destination_dir: str):
         """Unzips local 'addon_zip_path' to 'destination'.
 
         Args:

--- a/common/ayon_common/distribution/tests/test_addon_distributtion.py
+++ b/common/ayon_common/distribution/tests/test_addon_distributtion.py
@@ -1,7 +1,7 @@
 import copy
 import tempfile
+import dataclasses
 
-import attr
 import pytest
 
 from common.ayon_common.distribution.downloaders import (
@@ -155,7 +155,7 @@ def test_addon_info(printer, sample_addon_info):
     with pytest.raises(TypeError):
         assert addon["name"], "Dict approach not implemented"
 
-    addon_as_dict = attr.asdict(addon)
+    addon_as_dict = dataclasses.asdict(addon)
     assert addon_as_dict["name"], "Dict approach should work"
 
 


### PR DESCRIPTION
## Changelog Description
Use `dataclasses` instead of `attrs` for data holder classes in distribution logic.

## Testing notes:
1. Make sure you have things to distribute, at least one addon and dependency package -> You can remove them in appdirs for full distribution.
2. Run AYON launcher with this PR.
3. Distribution should be successful.
