### PR TITLE
Shim: Keep urllib in build

### DIFF
--- a/shim/setup.py
+++ b/shim/setup.py
@@ -56,7 +56,6 @@ build_exe_options = dict(
         "test",
         "tkinter",
         "unittest",
-        "urllib",
         "xmlrps",
     ]
 )


### PR DESCRIPTION
## Changelog Description
Keep `urllib` for `platformdirs` in build.

## Additional info
Module `platformdirs` does use `urllib` for internal logic.

## Testing notes:
1. Shim installation should still work.
