### PR TITLE
Chore: Permissions for AYON launcher installation on windows

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1406,7 +1406,11 @@ class AyonDistribution:
                 downloader_data,
                 f"Installer {installer_item.version}"
             )
-            if dist_item.is_missing_permissions:
+
+            if (
+                platform.system().lower() != "windows"
+                and dist_item.is_missing_permissions
+            ):
                 self._installer_dist_error = (
                     "Your user does not have required permissions to update"
                     " AYON launcher."


### PR DESCRIPTION
## Changelog Description
Windows distribution of AYON launcher does continu with installation even if requires admin permissions.

## Additional info
Windows does show "Ask for admin" dialog when installing AYON launcher so it is not necessary to skip the installation.

## Testing notes:
1. Build AYON launcher.
2. Install the version to Program files on windows.
3. Make sure current production bundle requires different AYON launcher version and also make sure that the version is not available on you machine.
4. Run this version.
5. It should start distrubtion and ask for admin privileges to install the update instead of showing dialog "You don't have required permissions" dialog.