### PR TITLE
macOs: Fix executable path on update

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -768,7 +768,7 @@ class InstallerDistributionItem(BaseDistributionItem):
         else:
             parsed_plist = plistlib.readPlist(plist_filepath)
         executable_filename = parsed_plist.get("CFBundleExecutable")
-        return os.path.join(
+        self._executable = os.path.join(
             contents_dir, "MacOS", executable_filename
         )
 


### PR DESCRIPTION
## Changelog Description
Set new executable path on AYON launcher update on macOs.

## Testing notes:
1. Automated update of AYON launcher on macOs does work.
