### PR TITLE
Remove forced pip update

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -206,8 +206,6 @@ create_env () {
   echo -e "${BIGreen}>>>${RST} Cleaning cache files ..."
   clean_pyc
 
-  "$poetry_home_root/bin/poetry" run python -m pip install --disable-pip-version-check --force-reinstall pip
-
   if [ -d "$repo_root/.git" ]; then
     echo -e "${BIGreen}>>>${RST} Installing pre-commit hooks ..."
     "$poetry_home_root/bin/poetry" run pre-commit install


### PR DESCRIPTION
## Changelog Description
pip version 24.1 and higher is not compatible with Python 3.7 hosts. We've freezed the version in #175 but we were still force-updating pip in the make/manage script when creating environment on Linux

## Testing notes:
- Build launcher
- Use it to run in some python 3.7 host (Maya 2020, 3dequalizer4 v7, ...)
