### PR TITLE
Chore: Allow to skip or block auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Environment variables that are set during startup:
 - **AYON_LAUNCHER_LOCAL_DIR** - Directory where are stored user/machine specific files. This MUST NOT be shared.
 - **AYON_ADDONS_DIR** - Path to AYON addons directory - Still used but considered as deprecated. Please rather use 'AYON_LAUNCHER_STORAGE_DIR' to change location.
 - **AYON_DEPENDENCIES_DIR** - Path to AYON dependencies directory - Still used but considered as deprecated. Please rather use 'AYON_LAUNCHER_STORAGE_DIR' to change location.
+- **AYON_AUTO_UPDATE** - Modify auto-update behavior which might be useful for shared distribution location. Missing AYON launcher, addon or dependency package won't be updated if is set to 'skip', instead will try to continue. And won't allow user to launch if is set to 'block' with brief explanation in a dialog.
 
 > [!NOTE]
 > Environment variables **AYON_LAUNCHER_STORAGE_DIR** and **AYON_LAUNCHER_LOCAL_DIR** are by default set to the same folder. Path is based on OS.

--- a/common/ayon_common/distribution/__init__.py
+++ b/common/ayon_common/distribution/__init__.py
@@ -5,6 +5,7 @@ from .exceptions import (
 from .control import AyonDistribution
 from .utils import (
     show_missing_permissions,
+    show_blocked_auto_update,
     show_missing_bundle_information,
     show_installer_issue_information,
     UpdateWindowManager,
@@ -18,6 +19,7 @@ __all__ = (
     "AyonDistribution",
 
     "show_missing_permissions",
+    "show_blocked_auto_update",
     "show_missing_bundle_information",
     "show_installer_issue_information",
     "UpdateWindowManager",

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -62,6 +62,22 @@ def show_missing_permissions():
     )
 
 
+def show_blocked_auto_update(launcher: bool):
+    if launcher:
+        message = "AYON launcher"
+    else:
+        message = "addons or dependency package"
+    _show_message_dialog(
+        "AYON distribution - Auto update blocked",
+        (
+            f"Update of {message} is required but auto-update"
+            f" is explicitly blocked."
+            "<br/><br/>Please contact your administrator to help you"
+            " resolve the issue."
+        ),
+    )
+
+
 def show_missing_bundle_information(url, bundle_name=None, username=None):
     """Show missing bundle information window.
 

--- a/start.py
+++ b/start.py
@@ -333,6 +333,7 @@ from ayon_common.distribution import (  # noqa E402
     AyonDistribution,
     BundleNotFoundError,
     show_missing_bundle_information,
+    show_blocked_auto_update,
     show_missing_permissions,
     show_installer_issue_information,
     UpdateWindowManager,
@@ -607,19 +608,38 @@ def _start_distribution():
     )
     _run_disk_mapping(bundle_name)
 
-    if distribution.is_missing_permissions:
-        show_missing_permissions()
-        sys.exit(1)
+    auto_update = (os.getenv("AYON_AUTO_UPDATE") or "").lower()
+    skip_auto_update = auto_update == "skip"
+    block_auto_update = auto_update == "block"
+    if distribution.need_distribution and not skip_auto_update:
+        if block_auto_update:
+            _print(
+                "!!! Automatic update is blocked by 'AYON_AUTO_UPDATE'."
+            )
+            if not HEADLESS_MODE_ENABLED:
+                show_blocked_auto_update(
+                    distribution.need_installer_distribution
+                )
+            sys.exit(1)
 
-    # Start distribution
-    update_window_manager = UpdateWindowManager()
-    if not HEADLESS_MODE_ENABLED:
-        update_window_manager.start()
+        if distribution.is_missing_permissions:
+            _print(
+                "!!! Failed to initialize distribution"
+                " because of permissions error."
+            )
+            if not HEADLESS_MODE_ENABLED:
+                show_missing_permissions()
+            sys.exit(1)
 
-    try:
-        distribution.distribute()
-    finally:
-        update_window_manager.stop()
+        # Start distribution
+        update_window_manager = UpdateWindowManager()
+        if not HEADLESS_MODE_ENABLED:
+            update_window_manager.start()
+
+        try:
+            distribution.distribute()
+        finally:
+            update_window_manager.stop()
 
     if distribution.need_installer_change:
         # Check if any error happened
@@ -643,8 +663,9 @@ def _start_distribution():
         #   - it can technically cause infinite loop of subprocesses
         sys.exit(subprocess.call(args))
 
-    # TODO check failed distribution and inform user
-    distribution.validate_distribution()
+        # TODO check failed distribution and inform user
+        distribution.validate_distribution()
+
     os.environ["AYON_BUNDLE_NAME"] = bundle_name
 
     # TODO probably remove paths to other addons?


### PR DESCRIPTION
## Changelog Description
Distribution can be skipped or blocked if something is missing using environment variable `AYON_AUTO_UPDATE`.

## Additional info
If the environment variable is set to `skip`, then any missing item to distribute (AYON laucher, addon, dependency package) will be skipped .

## Testing notes:
1. Remove an addon (e.g. maya) from addons dir.
2. Set env variable `AYON_AUTO_UPDATE` to `"skip"` (`$env:AYON_AUTO_UPDATE="skip"` in powershell).
3. Run AYON launcher.
4. Addon should not be distributed but AYON should launch ok (if is not missing crutial addon).
5. Close the progress.
6. Set env variable `AYON_AUTO_UPDATE` to `"block"` (`$env:AYON_AUTO_UPDATE="block"` in powershell).
7. Run AYON launcher.
8. A dialog should pop up with information that update is required but auto-update is blocked.
9. Unset the env (`$env:AYON_AUTO_UPDATE=""`).
10. Run AYON launcher.
11. Addon should be updated.
12. If you remove `core` addon and set the value to `"skip"` it should tell you that core is not available.