### PR TITLE
Chore: Fix attribute error in Installer

### DIFF
--- a/common/ayon_common/distribution/data_structures.py
+++ b/common/ayon_common/distribution/data_structures.py
@@ -249,7 +249,7 @@ class Installer:
     checksum_algorithm: str
     python_version: str
     python_modules: dict[str, str]
-    runtime_python_modules = dict[str, str]
+    runtime_python_modules: dict[str, str]
     sources: list[SourceInfo]
     unknown_sources: list[dict[str, Any]]
 


### PR DESCRIPTION
## Changelog Description
Fix wrong assignment instead of type annotation.

## Testing notes:
1. Installer initialization doesn't fail.
