### PR TITLE
Distribution: Unzipped content move is guarded

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1275,15 +1275,22 @@ class DistributionItem(BaseDistributionItem):
             # Rollback moved files
             for path in moved_paths:
                 if os.path.isfile(path):
-                    shutil.rmtree(path)
-                else:
                     os.remove(path)
+                else:
+                    shutil.rmtree(path)
 
             # Rename renamed files back to original
             for src_path, renamed_path in renamed_mapping:
                 os.rename(renamed_path, src_path)
 
             return False
+
+        # Remove renamed files
+        for _, renamed_path in renamed_mapping:
+            if os.path.isfile(renamed_path):
+                os.remove(renamed_path)
+            else:
+                shutil.rmtree(renamed_path)
 
         return super()._post_source_process(
             filepath, source_data, source_progress, downloader

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1236,12 +1236,13 @@ class DistributionItem(BaseDistributionItem):
         # Target directory can contain only distribution metadata file
         #   anything else is temporarily moved to different directory
         # NOTE: We might validate if the content is exactly same?
+        tmp_subfolder = uuid.uuid4().hex
         for name in os.listdir(self.target_dirpath):
             if name == DIST_PROGRESS_FILENAME:
                 continue
             current_path = os.path.join(self.target_dirpath, name)
             new_path = os.path.join(
-                os.path.dirname(self.target_dirpath), uuid.uuid4().hex, name
+                os.path.dirname(self.target_dirpath), tmp_subfolder, name
             )
             try:
                 os.rename(current_path, new_path)

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1235,8 +1235,11 @@ class DistributionItem(BaseDistributionItem):
 
         # Target directory can contain only distribution metadata file
         #   anything else is temporarily moved to different directory
+        #   - next to target directory
         # NOTE: We might validate if the content is exactly same?
-        tmp_subfolder = os.path.join(self.target_dirpath, uuid.uuid4().hex)
+        tmp_subfolder = os.path.join(
+            os.path.dirname(self.target_dirpath), uuid.uuid4().hex
+        )
         for name in os.listdir(self.target_dirpath):
             if name == DIST_PROGRESS_FILENAME:
                 continue


### PR DESCRIPTION
## Changelog Description
Try to catch possible issues that may happen during movement of unzipped directory.

## Additional info
Issue that can happen during distribution. Metadata file `addons.json` has invalid content or is missing and `dist_progress.json` file in addon has invalid content or is missing. In that case the addon folder does exists and may have correct content but distribution logic cannot tell. So it tries to distribute it, but fails on movement of unzipped content.

Solution is to first make sure that any existing content in target directory is temporarily moved to different folder. Then try to move new content. If any of that fails then remove any content that was moved and rename any content that was renamed to previous state. If it fails it also makes sure that the temp download directory is cleaned up.

## Testing notes:
1. Go to `%LOCALAPPDATA\Ynput\AYON\addons`.
2. Remove `addons.json`.
3. Remove `dist_progress.json` from one or more addons.
4. Run AYON launcher.
5. Before this PR it would crash and `%TEMP%\ayon_dist_downloads\` would contain remainders of downloaded content.
6. With this PR the addons should be distributed correctly and the download dir is empty (even if it fails).

### How to fake failed distribution of addon?
Not sure, you have to make sure that some file in addon is "in use". Didn't verify.
1. Run tray (maybe is enough?).
2. Repeat steps 1.-3. from testing notes.
3. Run new AYON launcher process.
4. It should fail but downloaded files should be cleared up.