### PR TITLE
Linux: App launcher don't wait for process to end

### DIFF
--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -71,6 +71,12 @@ int main(int argc, char *argv[]) {
         posix_spawn_file_actions_t file_actions;
         posix_spawn_file_actions_init(&file_actions);
 
+        // Redirect stdout to /dev/null
+        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+
+        // Redirect stderr to /dev/null
+        posix_spawn_file_actions_addopen(&file_actions, STDERR_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+
         posix_spawnattr_t spawnattr;
         posix_spawnattr_init(&spawnattr);
 
@@ -82,6 +88,8 @@ int main(int argc, char *argv[]) {
             setsid();
             return 1;
         }
+
+        posix_spawn_file_actions_destroy(&file_actions);
 
         for (int i = 0; i < env->size(); i++) {
             free(new_environ[i]);

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -77,11 +77,10 @@ int main(int argc, char *argv[]) {
         pid_t pid;
         int status = posix_spawn(&pid, exec_args[0], &file_actions, &spawnattr, exec_args, new_environ);
 
-        if (status == 0) {
-            int spawn_status;
-            waitpid(pid, &spawn_status, 0);
-        } else {
+        if (status != 0) {
             printf("posix_spawn: %s\n", strerror(status));
+            setsid();
+            return 1;
         }
 
         for (int i = 0; i < env->size(); i++) {


### PR DESCRIPTION
## Changelog Description
Do not wait for spawned process to end and dispatch stdout and stderr.

## Testing notes:
1. When traypublisher or dcc is launched on linux, it does not cause stuck of the process from which it was triggered.
