### PR TITLE
Docker build: Use Rocky 8.5 image

### DIFF
--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1,5 +1,5 @@
 # Build AYON launcher docker image
-FROM rockylinux:8 AS builder
+FROM rockylinux:8.5 AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
## Changelog Description
Use older Rocky 8 image which is usually used by VFX studios.
