### PR TITLE
App launcher: Fix running separate process when running from code

### DIFF
--- a/app_launcher.py
+++ b/app_launcher.py
@@ -6,8 +6,8 @@ is when closed or blocked to be closed.
 
 import os
 import sys
-import subprocess
 import json
+import shlex
 
 
 def main(input_json_path):
@@ -36,7 +36,7 @@ def main(input_json_path):
     # Prepare launch arguments
     args = data["args"]
     if isinstance(args, list):
-        args = subprocess.list2cmdline(args)
+        args = shlex.join(args)
 
     # Run the command as background process
     shell_cmd = args + " &"


### PR DESCRIPTION
## Changelog Description
Use `shlex` to create command in `app_launcher.py` to properly escape characters for linux bash.

## Testing notes:
1. Webactions started from ayon-core's launcher tool should be starting correctly.
