### PR TITLE
Chore: Avoid permissions issues

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -237,12 +237,9 @@ def _wait_for_other_process(
     yield output
 
 
-def change_permissions_recursive(path: str, mode: Optional[int] = None):
+def change_permissions_recursive(path: str, mode: int = 0o777):
     if IS_WINDOWS or not os.path.exists(path):
         return
-
-    if mode is None:
-        mode = 0o777
 
     if os.path.isfile(path):
         # If the path is a file, change its permissions directly

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -300,7 +300,12 @@ def _cleanup_dist_expire_dirs(process_dir: str):
     for subname in os.listdir(process_dir):
         path = os.path.join(process_dir, subname)
         if os.path.isdir(path) and _dist_expire_file_expired(path):
-            shutil.rmtree(path)
+            try:
+                shutil.rmtree(path)
+            except Exception:
+                print(
+                    f"Failed to remove expired distribution directory: {path}"
+                )
 
 
 def _cleanup_dist_download_dirs():

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -50,6 +50,7 @@ from .downloaders import (
 NOT_SET = type("UNKNOWN", (), {"__bool__": lambda: False})()
 DIST_PROGRESS_FILENAME = "dist_progress.json"
 MOVE_WAIT_TRESHOLD_TIME = 20
+IS_WINDOWS = platform.system().lower() == "windows"
 
 
 class DistributionProgressInterupted(Exception):
@@ -77,7 +78,6 @@ def _windows_dir_requires_permissions(dirpath: str) -> bool:
 
 
 def _has_write_permissions(dirpath: str) -> bool:
-    platform_name = platform.system().lower()
     while not os.path.exists(dirpath):
         _dirpath = os.path.dirname(dirpath)
         if _dirpath == dirpath:
@@ -88,7 +88,7 @@ def _has_write_permissions(dirpath: str) -> bool:
             return False
         dirpath = _dirpath
 
-    if platform_name == "windows":
+    if IS_WINDOWS:
         if ctypes.windll.shell32.IsUserAnAdmin():
             return True
 


### PR DESCRIPTION
## Changelog Description
Try to avoid possible permissions issues with temp directories.

## Additional info
Make sure that created temp directories have `777` permissions so other users can clean it up. It is common that linux machine uses different users, e.g. one for farm and one for artist, in that case they can't cleanup temp directories which might be blocking.

## Testing notes:
I don't know how to test. The most important part is that `/tmp/ayon_dist_downloads` has `777` mode permissions instead of `775`.
