### PR TITLE
Chore: More attempts to rename unzipped folder

### DIFF
--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -640,8 +640,10 @@ def extract_archive_file(archive_file: str, dst_folder: Optional[str] = None):
 
     if archive_type == "zip":
         zip_file = ZipFileLongPaths(archive_file)
-        zip_file.extractall(dst_folder)
-        zip_file.close()
+        try:
+            zip_file.extractall(dst_folder)
+        finally:
+            zip_file.close()
 
     elif archive_type == "tar":
         if archive_ext == ".tar":
@@ -660,8 +662,10 @@ def extract_archive_file(archive_file: str, dst_folder: Optional[str] = None):
         except tarfile.ReadError:
             raise SystemExit("corrupted archive")
 
-        tar_file.extractall(dst_folder)
-        tar_file.close()
+        try:
+            tar_file.extractall(dst_folder)
+        finally:
+            tar_file.close()
 
 
 def calculate_file_checksum(


### PR DESCRIPTION
## Changelog Description
Try to rename archive to target name multiple times.

## Additional info
For some reason it might be possible that it is not possible to rename the unzipped content for a first time, but it is possible later. There was added an attempt counter to try to achieve the rename 5 times which seems to resolve issues we have with distrubution.

## Testing notes:
I don't know I wasn't able to reproduce the issue localy. Distribution of addon and dependency packages still works.
1. Build launcher and use it in bundle, or run the launcher from code.
2. Remove all addons and dependency packages from `%LOCALAPPDATA\Ynput\AYON`.
3. Launch AYON launcher to trigger distribution.
4. Everything is distributed ok.

Resolves https://github.com/ynput/ayon-launcher/issues/239