### PR TITLE
App launcher: Store pid of launched process back to the json file

### DIFF
--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
         }
         std::ofstream output_file(argv[1]);
         if (output_file.is_open()) {
-            output_file << root.dump(4);
+            output_file << root.dump();
             output_file.close();
         } else {
             fprintf(stderr, "error: could not write back to file %s\n", argv[1]);

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "error: %s\n", e.what());
         return 1;
     }
+    json_file.close();
 
     auto env = root.find("env");
     char **new_environ = NULL;
@@ -83,6 +84,18 @@ int main(int argc, char *argv[]) {
 
         pid_t pid;
         int status = posix_spawn(&pid, exec_args[0], &file_actions, &spawnattr, exec_args, new_environ);
+        if (status == 0) {
+            root["pid"] = pid;
+        } else {
+            root["pid"] = nullptr;
+        }
+        std::ofstream output_file(argv[1]);
+        if (output_file.is_open()) {
+            output_file << root.dump(4);
+            output_file.close();
+        } else {
+            fprintf(stderr, "error: could not write back to file %s\n", argv[1]);
+        }
 
         if (status != 0) {
             printf("posix_spawn: %s\n", strerror(status));


### PR DESCRIPTION
## Changelog Description
Store PID of launched process back to the json file.

## Additional information
The PID is important part of information that is not used at this moment but will be in near future.

## Testing notes:
1. Build AYON launcher, upload to server and use it in a bundle.
2. Applications can be launched from AYON launcher or webactions.
3. The json file will contain the pid.