### PR TITLE
Distribution: Try to find existing launcher executable

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1893,6 +1893,35 @@ class AYONDistribution:
         if path and filename == "ayon_console.exe":
             path = os.path.join(os.path.dirname(path), filename)
 
+        if path:
+            self._installer_executable = path
+            return path
+
+        # Guess based on "expected" path of the version
+        # - is used if the AYON is already installed at target location but is
+        #   missing in the metadata file
+        current_version = os.environ["AYON_VERSION"]
+        platform_name = platform.system().lower()
+        if platform_name in {"windows", "linux"}:
+            executable_dir, exe_name = os.path.split(sys.executable)
+            install_root, dirname = os.path.split(executable_dir)
+            if current_version in dirname:
+                new_dirname = dirname.replace(
+                    current_version,
+                    self.expected_installer_version
+                )
+                executable = os.path.join(
+                    install_root, new_dirname, exe_name
+                )
+                if os.path.exists(executable):
+                    path = executable
+
+        elif platform_name == "darwin":
+            app_name = f"AYON {self.expected_installer_version}.app"
+            excutable = f"/Applications/{app_name}/Contents/MacOS/ayon"
+            if os.path.exists(excutable):
+                path = excutable
+
         self._installer_executable = path
         return path
 

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1866,32 +1866,32 @@ class AYONDistribution:
 
         path = None
         if not self.need_installer_change:
-            path = sys.executable
+            self._installer_executable = sys.executable
+            return self._installer_executable
 
-        else:
-            # Compare existing executable with current executable
-            current_executable = sys.executable
-            # Use 'ayon.exe' for executable lookup on Windows
-            root, filename = os.path.split(current_executable)
-            if filename == "ayon_console.exe":
-                current_executable = os.path.join(root, "ayon.exe")
+        # Compare existing executable with current executable
+        current_executable = sys.executable
+        # Use 'ayon.exe' for executable lookup on Windows
+        root, filename = os.path.split(current_executable)
+        if filename == "ayon_console.exe":
+            current_executable = os.path.join(root, "ayon.exe")
 
-            # TODO look to expected target install directory too
-            executables_info = get_executables_info_by_version(
-                self.expected_installer_version)
-            for executable_info in executables_info:
-                executable_path = executable_info.get("executable")
-                if (
-                    not os.path.exists(executable_path)
-                    or executable_path == current_executable
-                ):
-                    continue
-                path = executable_path
-                break
+        # TODO look to expected target install directory too
+        executables_info = get_executables_info_by_version(
+            self.expected_installer_version)
+        for executable_info in executables_info:
+            executable_path = executable_info.get("executable")
+            if (
+                not os.path.exists(executable_path)
+                or executable_path == current_executable
+            ):
+                continue
+            path = executable_path
+            break
 
-            # Make sure current executable filename is used on Windows
-            if path and filename == "ayon_console.exe":
-                path = os.path.join(os.path.dirname(path), filename)
+        # Make sure current executable filename is used on Windows
+        if path and filename == "ayon_console.exe":
+            path = os.path.join(os.path.dirname(path), filename)
 
         self._installer_executable = path
         return path


### PR DESCRIPTION
## Changelog Description
Use guessed executable path of expected version if exists.

## Additional info
Before this PR we only used executables that are stored in metadata json file. With this we also look into "expected" path of requested version to avoid unnecessary re-installation of the same version.

## Testing notes:
1. Install some older version of AYON launcher (e.g. 1.3.2).
2. Use it in your bundle.
3. Remove the older version from `%LOCALAPPDATA%\Ynput\AYON\executables.json`.
4. Install this version of launcher.
5. Start this version.
6. It should not try ti re-install 1.3.2, but just use it.