### PR TITLE
Project bundles: Fix fetch of project bundle

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2776,7 +2776,7 @@ class AYONDistribution:
         if self._project_bundle_name == studio_bundle_name:
             self._project_bundle = None
             return None
-        
+
         if (
             not self._project_bundle_name
             and self._project_name is not NOT_SET

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2771,6 +2771,12 @@ class AYONDistribution:
         if self._project_bundle is not NOT_SET:
             return self._project_bundle
 
+        # Project bundle is set and is same as studio bundle
+        studio_bundle_name = self.studio_bundle_to_use.name
+        if self._project_bundle_name == studio_bundle_name:
+            self._project_bundle = None
+            return None
+        
         if (
             not self._project_bundle_name
             and self._project_name is not NOT_SET
@@ -2801,7 +2807,6 @@ class AYONDistribution:
         if bundle is None:
             raise BundleNotFoundError(self._project_bundle_name)
 
-        studio_bundle_name = self.studio_bundle_to_use.name
         if studio_bundle_name:
             key_values = {
                 "summary": "true",


### PR DESCRIPTION
## Changelog Description
Ignore project bundle name if is same as studio bundle.

## Additional info
If project bundle is not defined then it is filled with studio bundle name. On subprocess launch is the bundle tried to be found as project bundle leading to crashes.

### Traceback
```
Traceback (most recent call last):
  File "~\ayon\ayon-launcher\start.py", line 1152, in <module>
    main()
  File "~\ayon\ayon-launcher\start.py", line 1142, in main
    boot()
  File "~\ayon\ayon-launcher\start.py", line 787, in boot
    _start_distribution()
  File "~\ayon\ayon-launcher\start.py", line 597, in _start_distribution
    project_bundle = distribution.project_bundle_to_use
  File "~\ayon\ayon-launcher\common\ayon_common\distribution\control.py", line 1766, in project_bundle_to_use
    project_bundle = self._get_project_bundle()
  File "~\ayon\ayon-launcher\common\ayon_common\distribution\control.py", line 2814, in _get_project_bundle
    for addon in response.data["addons"]:
KeyError: 'addons'
```

## Testing notes:
1. AYON launcher subprocess don't crash.
