### PR TITLE
Add info about API  key being used and handle missing bundles

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2600,9 +2600,19 @@ class AYONDistribution:
                 studio_staging_bundle = bundle
             if bundle.is_dev and bundle.active_dev_user == self.active_user:
                 studio_dev_bundle = bundle
+
         self._studio_production_bundle = studio_production_bundle
         self._studio_staging_bundle = studio_staging_bundle
         self._studio_dev_bundle = studio_dev_bundle
+        if (
+                not self._studio_production_bundle
+                or not self._studio_staging_bundle
+                or not self._studio_dev_bundle):
+            msg = (
+                "Server does not have defined required production, "
+                f'staging or dev bundle (for user "{self.active_user}").'
+            )
+            raise RuntimeError(msg)
 
     def _prepare_current_addon_dist_items(self) -> list[dict[str, Any]]:
         addons_metadata = self.get_addons_metadata()

--- a/start.py
+++ b/start.py
@@ -400,6 +400,8 @@ def _connect_to_ayon_server(force=False, username=None):
         need_server, need_api_key = need_server_or_login(username)
 
     current_url = os.environ.get(SERVER_URL_ENV_KEY)
+    if os.getenv(SERVER_API_ENV_KEY):
+        _print("*** Using API key from environment variable to connect")
     if not need_server and not need_api_key:
         _print(f">>> Connected to AYON server {current_url}")
         return


### PR DESCRIPTION
## Changelog Description
Add info to console about API key being used from environment variable as it might massively change behavior of the launcher logic. Also handle better error when no usable bundle can be found.

## Testing notes:
1. Unset any dev bundles
2. Run ayon with `--use-dev` - you should get more informative error
3. Set `AYON_API_KEY` in current terminal session
4. Run ayon - you should see line stating that API key is used from environment variable
