### PR TITLE
Resolve environment variables in dev bundle addon paths

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2582,9 +2582,15 @@ class AYONDistribution:
 
             dev_addon_info = dev_addons.get(addon_name)
             if dev_addon_info is not None and dev_addon_info.enabled:
-                output.append(
-                    dev_addon_info.path.format(os.environ)
-                )
+                try:
+                    output.append(
+                        dev_addon_info.path.format(**os.environ)
+                    )
+                except KeyError:
+                    self.log.warning(
+                        f"Failed to format path '{dev_addon_info.path}'"
+                        " for addon '{addon_name}'."
+                    )
 
         return output
 

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2582,7 +2582,9 @@ class AYONDistribution:
 
             dev_addon_info = dev_addons.get(addon_name)
             if dev_addon_info is not None and dev_addon_info.enabled:
-                output.append(dev_addon_info.path)
+                output.append(
+                    dev_addon_info.path.format(os.environ)
+                )
 
         return output
 


### PR DESCRIPTION
## Changelog Description
Add support of resolution of environment variables in dev bundle addon paths. You can use standard `{FOO_BAR}` format within the path. This can be used to set dev bundle to work on multiple platforms provided the environment variable is set there.

## Additional info
This also needs PR in `ayon-core` - [ayon-core/#1429](https://github.com/ynput/ayon-core/pull/1429)

## Testing notes:
1. In dev bundle, set path to addons like `{DEV_ADDONS}/ayon-core/client`
2. Set this environment variable so the path exist and can be resolved
3. Run AYON

