### PR TITLE
App launcher: Allow to pass in stdout and stderr paths

### DIFF
--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -19,8 +19,6 @@ g++ app_launcher.cpp -o app_launcher
 #include <sys/wait.h>
 #include <string.h>
 #include <fstream>
-#include <thread>
-#include <chrono>
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
@@ -50,14 +48,6 @@ int main(int argc, char *argv[]) {
     char **new_environ = NULL;
     if (env != root.end() && env->is_object()) {
         int env_size = env->size();
-
-        // Check if we need to add AYON_PID_FILE to environment
-        auto pid_file_it = root.find("pid_file");
-        bool has_pid_file = (pid_file_it != root.end() && pid_file_it->is_string());
-        if (has_pid_file && env->find("AYON_PID_FILE") == env->end()) {
-            env_size++; // Add space for AYON_PID_FILE
-        }
-
         new_environ = (char **)malloc((env_size + 1) * sizeof(char *));
         int i = 0;
 
@@ -68,24 +58,7 @@ int main(int argc, char *argv[]) {
                 i++;
             }
         }
-
-        // Add AYON_PID_FILE environment variable if pid_file is specified
-        if (has_pid_file && env->find("AYON_PID_FILE") == env->end()) {
-            std::string pid_file_env = "AYON_PID_FILE=" + pid_file_it->get<std::string>();
-            new_environ[i] = strdup(pid_file_env.c_str());
-            i++;
-        }
-
         new_environ[env_size] = NULL;
-    } else {
-        // No env object, but check if we need to create one for pid_file
-        auto pid_file_it = root.find("pid_file");
-        if (pid_file_it != root.end() && pid_file_it->is_string()) {
-            new_environ = (char **)malloc(2 * sizeof(char *));
-            std::string pid_file_env = "AYON_PID_FILE=" + pid_file_it->get<std::string>();
-            new_environ[0] = strdup(pid_file_env.c_str());
-            new_environ[1] = NULL;
-        }
     }
     auto stdoutIt = root.find("stdout");
     std::string outPathStr;
@@ -140,49 +113,13 @@ int main(int argc, char *argv[]) {
         posix_spawnattr_t spawnattr;
         posix_spawnattr_init(&spawnattr);
 
-        pid_t initial_pid;
-        int status = posix_spawn(&initial_pid, exec_args[0], &file_actions, &spawnattr, exec_args, new_environ);
-
-        pid_t final_pid = initial_pid;
-
+        pid_t pid;
+        int status = posix_spawn(&pid, exec_args[0], &file_actions, &spawnattr, exec_args, new_environ);
         if (status == 0) {
-            // Check if shell script provided actual application PID via PID file
-            auto pid_file_it = root.find("pid_file");
-            if (pid_file_it != root.end() && pid_file_it->is_string()) {
-                std::string pid_file_path = pid_file_it->get<std::string>();
-
-                // Wait a short time for shell script to potentially write actual PID
-                std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-                std::ifstream pid_file(pid_file_path);
-                if (pid_file.is_open()) {
-                    std::string pid_content;
-                    std::getline(pid_file, pid_content);
-                    pid_file.close();
-
-                    // Remove any whitespace
-                    pid_content.erase(0, pid_content.find_first_not_of(" \t\r\n"));
-                    pid_content.erase(pid_content.find_last_not_of(" \t\r\n") + 1);
-
-                    if (!pid_content.empty()) {
-                        try {
-                            pid_t script_pid = std::stoi(pid_content);
-                            if (script_pid != initial_pid && script_pid > 0) {
-                                final_pid = script_pid;
-                                printf("Shell script provided actual application PID: %d\n", script_pid);
-                            }
-                        } catch (const std::exception& e) {
-                            // Invalid PID in file, use initial_pid
-                        }
-                    }
-                }
-            }
-
-            root["pid"] = final_pid;
+            root["pid"] = pid;
         } else {
             root["pid"] = nullptr;
         }
-
         std::ofstream output_file(argv[1]);
         if (output_file.is_open()) {
             output_file << root.dump();

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -1,7 +1,10 @@
 /**
-This is a simple C++ equivalent of the `app_launcher.py` with one difference:
-it completely detach from the parent process. This is needed to avoid
-hanging child processes when the parent process is killed.
+LINUX only
+
+This is a simple C++ application to start process and completely detach it
+from the parent process. This is needed to avoid hanging child processes
+when the parent process is killed.
+
 You can use it instead of the `app_launcher.py` by building it with:
 ```shell
 CPLUS_INCLUDE_PATH=/../ayon-launcher/vendor/include

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]) {
     bool addStderrRedirection = true;
     if (stderrIt != root.end()) {
         if (stderrIt->is_null()) {
-            addstderrRedirection = false;  // do not redirect stderr if explicitly null
+            addStderrRedirection = false;  // do not redirect stderr if explicitly null
         } else if (stderrIt->is_string()) {
             errPathStr = stderrIt->get<std::string>();
         }

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -57,6 +57,20 @@ int main(int argc, char *argv[]) {
         }
         new_environ[env_size] = NULL;
     }
+    auto stdout = root.find("stdout");
+    std::string outPathStr;
+    if (stdoutIt != root.end() && stdoutIt->is_string()) {
+        outPathStr = stdoutIt->get<std::string>();
+    }
+    if (outPathStr.empty()) outPathStr = "/dev/null";
+
+    auto stderr = root.find("stderr");
+    std::string errPathStr;
+    if (stderrIt != root.end() && stderrIt->is_string()) {
+        errPathStr = stderrIt->get<std::string>();
+    }
+    if (errPathStr.empty()) errPathStr = "/dev/null";
+
     auto args = root.find("args");
     if (args != root.end() && args->is_array()) {
         char **exec_args = (char **)malloc((args->size() + 2) * sizeof(char *));
@@ -74,10 +88,10 @@ int main(int argc, char *argv[]) {
         posix_spawn_file_actions_init(&file_actions);
 
         // Redirect stdout to /dev/null
-        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, outPathStr.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
         // Redirect stderr to /dev/null
-        posix_spawn_file_actions_addopen(&file_actions, STDERR_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        posix_spawn_file_actions_addopen(&file_actions, STDERR_FILENO, errPathStr.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
         posix_spawnattr_t spawnattr;
         posix_spawnattr_init(&spawnattr);

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -4,6 +4,8 @@ This is written for linux distributions where process tree may affect what
 is when closed or blocked to be closed.
 """
 
+
+import contextlib
 import os
 import sys
 import json
@@ -31,6 +33,12 @@ def main(input_json_path):
 
     # Change environment variables
     env = data.get("env") or {}
+
+    # Add AYON_PID_FILE environment variable if pid_file is specified
+    pid_file_path = data.get("pid_file")
+    if pid_file_path and "AYON_PID_FILE" not in env:
+        env["AYON_PID_FILE"] = pid_file_path
+
     for key, value in env.items():
         os.environ[key] = value
 
@@ -74,11 +82,27 @@ def main(input_json_path):
     os.remove(pid_path)
 
     try:
-        pid = int(content)
+        initial_pid = int(content)
     except Exception:
-        pid = None
+        initial_pid = None
 
-    data["pid"] = pid
+    # Check if shell script provided actual application PID via PID file
+    final_pid = initial_pid
+    pid_file_path = data.get("pid_file")
+    if pid_file_path and final_pid:
+        # Wait a short time for shell script to potentially write actual PID
+        import time
+        time.sleep(0.5)  # Give shell script time to launch app and write PID
+
+        with contextlib.suppress(OSError, ValueError):
+            with open(pid_file_path, "r") as pid_file:
+                script_pid_content = pid_file.read().strip()
+                if script_pid_content.isdigit():
+                    script_pid = int(script_pid_content)
+                    # Only use if different from shell PID
+                    if script_pid != final_pid:
+                        final_pid = script_pid
+    data["pid"] = final_pid
     with open(input_json_path, "w") as stream:
         json.dump(data, stream)
     sys.exit(0)

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -43,7 +43,30 @@ def main(input_json_path):
     with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
         pid_path = tmpfile.name
 
-    shell_cmd = args + f" & && echo $! > {pid_path}"
+    stdout_path = stderr_path = "/dev/null"
+    if "stdout" in data:
+        stdout_path = data["stdout"]
+
+    if "stderr" in data:
+        stderr_path = data["stderr"]
+
+    post_args = []
+    if stdout_path:
+        stdout = f">{stdout_path}"
+        post_args.append(stdout)
+
+    if stderr_path:
+        if stdout_path == stderr_path:
+            stderr_path = "&1"
+        stderr = f"2>{stderr_path}"
+        post_args.append(stderr)
+
+    post_args_s = ""
+    if post_args:
+        joined_ags = " ".join(post_args)
+        post_args_s = f" {joined_ags}"
+
+    shell_cmd = f"{args}{post_args_s} & echo $! > {pid_path}"
     os.system(shell_cmd)
 
     with open(pid_path, "r") as stream:


### PR DESCRIPTION
## Changelog Description
App laucher can pass stdout and stderr paths from the json file. Or allows to not change stdout and stderr if json explicitly tells to not to.

## Testing notes:
### Base
1. App launcher works.

### Redirection
1. Prepare testing json file.
2. Add `"stdout"` and `"stderr"` with paths to custom paths.
3. Run applauncher with path to the json file.
4. The stdout and stderr files are used.