### PR TITLE
App launcher: allows to pass custom PID back to AYON

### DIFF
--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -1,7 +1,10 @@
 /**
-This is a simple C++ equivalent of the `app_launcher.py` with one difference:
-it completely detach from the parent process. This is needed to avoid
-hanging child processes when the parent process is killed.
+LINUX only
+
+This is a simple C++ application to start process and completely detach it
+from the parent process. This is needed to avoid hanging child processes
+when the parent process is killed.
+
 You can use it instead of the `app_launcher.py` by building it with:
 ```shell
 CPLUS_INCLUDE_PATH=/../ayon-launcher/vendor/include

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[]) {
     bool addStderrRedirection = true;
     if (stderrIt != root.end()) {
         if (stderrIt->is_null()) {
-            addstderrRedirection = false;  // do not redirect stderr if explicitly null
+            addStderrRedirection = false;  // do not redirect stderr if explicitly null
         } else if (stderrIt->is_string()) {
             errPathStr = stderrIt->get<std::string>();
         }

--- a/app_launcher.cpp
+++ b/app_launcher.cpp
@@ -57,6 +57,20 @@ int main(int argc, char *argv[]) {
         }
         new_environ[env_size] = NULL;
     }
+    auto stdout = root.find("stdout");
+    std::string outPathStr;
+    if (stdoutIt != root.end() && stdoutIt->is_string()) {
+        outPathStr = stdoutIt->get<std::string>();
+    }
+    if (outPathStr.empty()) outPathStr = "/dev/null";
+
+    auto stderr = root.find("stderr");
+    std::string errPathStr;
+    if (stderrIt != root.end() && stderrIt->is_string()) {
+        errPathStr = stderrIt->get<std::string>();
+    }
+    if (errPathStr.empty()) errPathStr = "/dev/null";
+
     auto args = root.find("args");
     if (args != root.end() && args->is_array()) {
         char **exec_args = (char **)malloc((args->size() + 2) * sizeof(char *));
@@ -74,10 +88,10 @@ int main(int argc, char *argv[]) {
         posix_spawn_file_actions_init(&file_actions);
 
         // Redirect stdout to /dev/null
-        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, outPathStr.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
         // Redirect stderr to /dev/null
-        posix_spawn_file_actions_addopen(&file_actions, STDERR_FILENO, "/dev/null", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        posix_spawn_file_actions_addopen(&file_actions, STDERR_FILENO, errPathStr.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
         posix_spawnattr_t spawnattr;
         posix_spawnattr_init(&spawnattr);

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -4,6 +4,8 @@ This is written for linux distributions where process tree may affect what
 is when closed or blocked to be closed.
 """
 
+
+import contextlib
 import os
 import sys
 import json
@@ -31,6 +33,12 @@ def main(input_json_path):
 
     # Change environment variables
     env = data.get("env") or {}
+
+    # Add AYON_PID_FILE environment variable if pid_file is specified
+    pid_file_path = data.get("pid_file")
+    if pid_file_path and "AYON_PID_FILE" not in env:
+        env["AYON_PID_FILE"] = pid_file_path
+
     for key, value in env.items():
         os.environ[key] = value
 
@@ -74,11 +82,27 @@ def main(input_json_path):
     os.remove(pid_path)
 
     try:
-        pid = int(content)
+        initial_pid = int(content)
     except Exception:
-        pid = None
+        initial_pid = None
 
-    data["pid"] = pid
+    # Check if shell script provided actual application PID via PID file
+    final_pid = initial_pid
+    pid_file_path = data.get("pid_file")
+    if pid_file_path and final_pid:
+        # Wait a short time for shell script to potentially write actual PID
+        import time
+        time.sleep(0.5)  # Give shell script time to launch app and write PID
+
+        with contextlib.suppress(OSError, ValueError):
+            with open(pid_file_path, "r") as pid_file:
+                script_pid_content = pid_file.read().strip()
+                if script_pid_content.isdigit():
+                    script_pid = int(script_pid_content)
+                    # Only use if different from shell PID
+                    if script_pid != final_pid:
+                        final_pid = script_pid
+    data["pid"] = final_pid
     with open(input_json_path, "w") as stream:
         json.dump(data, stream)
     sys.exit(0)

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -43,7 +43,30 @@ def main(input_json_path):
     with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
         pid_path = tmpfile.name
 
-    shell_cmd = args + f" & && echo $! > {pid_path}"
+    stdout_path = stderr_path = "/dev/null"
+    if "stdout" in data:
+        stdout_path = data["stdout"]
+
+    if "stderr" in data:
+        stderr_path = data["stderr"]
+
+    post_args = []
+    if stdout_path:
+        stdout = f">{stdout_path}"
+        post_args.append(stdout)
+
+    if stderr_path:
+        if stdout_path == stderr_path:
+            stderr_path = "&1"
+        stderr = f"2>{stderr_path}"
+        post_args.append(stderr)
+
+    post_args_s = ""
+    if post_args:
+        joined_ags = " ".join(post_args)
+        post_args_s = f" {joined_ags}"
+
+    shell_cmd = f"{args}{post_args_s} & echo $! > {pid_path}"
     os.system(shell_cmd)
 
     with open(pid_path, "r") as stream:


### PR DESCRIPTION
## Changelog Description
When launching application using wrapper shell scripts, give possibility to pass resulting PID back. This allows to track the main process in Process Manager implemented in ynput/ayon-applications#94

## Additional info
JSON passed to *app_launcher* has `pid_file` entry. If set, *app_launcher* will set `AYON_PID_FILE` environment variable just before the process is launched. If it is the shell script (but frankly, whatever else) it can take this variable, write the PID there. This is then read back and used to monitor the process.

> [!NOTE]
> This already has changes from #254 

## Testing notes:
1. Set the executable to be the script like:
```bash
#!/bin/bash

# Launch the actual application in background
/path/to/actual/application "$@" &

# Get the PID of the actual application
APP_PID=$!

# Write the PID to the AYON PID file if available
if [ -n "$AYON_PID_FILE" ]; then
    echo "$APP_PID" > "$AYON_PID_FILE"
fi
```

2. The Process Manager should show the correct PID
