### PR TITLE
Chore: Freeze poetry at 2.1.2

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -138,6 +138,7 @@ detect_python () {
 install_poetry () {
   echo -e "${BIGreen}>>>${RST} Installing Poetry ..."
   export POETRY_HOME=$poetry_home_root
+  export POETRY_VERSION=2.1.2
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -sSL https://install.python-poetry.org/ | python -
 

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -117,6 +117,7 @@ function Install-Poetry() {
     }
 
     $env:POETRY_HOME=$poetry_home
+    $env:POETRY_VERSION="2.1.2"
     (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python)
 }
 


### PR DESCRIPTION
## Changelog Description
Poetry is frozen at version 2.1.2 .

## Additional info
New version of poetry removed `poetry_lock.json` file which is source of imformation for metadata file.

## Testing notes:
1. Making installer works.
