### PR TITLE
Chore: Change bundle arguments handling

### DIFF
--- a/start.py
+++ b/start.py
@@ -101,16 +101,16 @@ if "--bundle" in sys.argv:
         raise RuntimeError((
             "Expect value after \"--bundle\" argument."
         ))
-    os.environ["AYON_BUNDLE_NAME"] = sys.argv.pop(idx)
+    os.environ["AYON_STUDIO_BUNDLE_NAME"] = sys.argv.pop(idx)
 
-if "--studio-bundle" in sys.argv:
-    idx = sys.argv.index("----studio-bundle")
+if "--project-bundle" in sys.argv:
+    idx = sys.argv.index("--project-bundle")
     sys.argv.pop(idx)
     if idx >= len(sys.argv):
         raise RuntimeError((
-            "Expect value after \"----studio-bundle\" argument."
+            "Expect value after \"---project-bundle\" argument."
         ))
-    os.environ["AYON_STUDIO_BUNDLE_NAME"] = sys.argv.pop(idx)
+    os.environ["AYON_BUNDLE_NAME"] = sys.argv.pop(idx)
 
 if "--project" in sys.argv:
     idx = sys.argv.index("--project") + 1


### PR DESCRIPTION
## Changelog Description
Use `--bundle` to specify studio bundle and replace `--studio-bundle` with `--project-bundle`.

## Additional info
Using `--bundle` for project bundle did not make sense. There was also a bug -> using `----studio-bundle` instead of `--studio-bundle` string leading to crashes if was used.

This change also makes it work more as it did work before 1.4.0 release.

## Testing notes:
1. Using `--bundle` will define which studio bundle is used.
