### PR TITLE
Fix: OSX Cannot switch using Cmd + Tab

### DIFF
--- a/tools/make.sh
+++ b/tools/make.sh
@@ -236,8 +236,6 @@ fix_macos_build () {
   ayonexe="$macosdir/ayon"
   ayonmacosexe="$macosdir/ayon_macos"
   tmp_ayonexe="$macosdir/ayon_tmp"
-  # force hide icon from Dock
-  defaults write "$macoscontents/Info" LSUIElement 1
 
   # Fix codesign bug by creating copy of executable, removing source
   #   executable and replacing by the copy


### PR DESCRIPTION
Fix #68

## Changelog Description
OSX: Fix switching `Cmd + Tab`

## Testing notes:
1. Build for OSX
2. Open any window like the launcher
3. Do `Cmd + Tab`
