### PR TITLE
Chore: Add path to PYTHONPATH in correct order

### DIFF
--- a/common/ayon_common/distribution/__init__.py
+++ b/common/ayon_common/distribution/__init__.py
@@ -4,6 +4,8 @@ from .exceptions import (
 )
 from .control import AYONDistribution
 from .utils import (
+    get_addons_dir,
+    get_dependencies_dir,
     show_missing_permissions,
     show_blocked_auto_update,
     show_missing_bundle_information,
@@ -18,6 +20,8 @@ __all__ = (
 
     "AYONDistribution",
 
+    "get_addons_dir",
+    "get_dependencies_dir",
     "show_missing_permissions",
     "show_blocked_auto_update",
     "show_missing_bundle_information",

--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -2538,38 +2538,38 @@ class AYONDistribution:
                 output.append(runtime_dir)
         return output
 
-    def get_python_paths(self) -> list[str]:
+    def get_python_paths(self) -> tuple[list[str], Optional[str]]:
         """Get all paths to python packages that should be added to python.
 
         These paths lead to addon directories and python dependencies in
         dependency package.
 
         Returns:
-            List[str]: Paths that should be added to 'sys.path' and
-                'PYTHONPATH'.
+            tuple[list[str], Optional[str]]: Paths that should be added
+                to 'sys.path' and 'PYTHONPATH'.
 
         """
-        output = []
+        addon_paths = []
         for item in self.get_addon_dist_items():
             dist_item = item["dist_item"]
             if dist_item.state != UpdateState.UPDATED:
                 continue
             target_dirpath = dist_item.target_dirpath
             if target_dirpath and os.path.exists(target_dirpath):
-                output.append(target_dirpath)
+                addon_paths.append(target_dirpath)
 
-        output.extend(self._get_dev_sys_paths())
+        addon_paths.extend(self._get_dev_sys_paths())
 
+        dependencies_dir = None
         dependency_dist_item = self.get_dependency_dist_item()
         if dependency_dist_item is not None:
-            dependencies_dir = None
             target_dirpath = dependency_dist_item.target_dirpath
             if target_dirpath:
                 dependencies_dir = os.path.join(target_dirpath, "dependencies")
 
-            if dependencies_dir and os.path.exists(dependencies_dir):
-                output.append(dependencies_dir)
-        return output
+            if not dependencies_dir or not os.path.exists(dependencies_dir):
+                dependencies_dir = None
+        return addon_paths, dependencies_dir
 
     def _get_dev_sys_paths(self) -> list[str]:
         output = []

--- a/start.py
+++ b/start.py
@@ -789,8 +789,9 @@ def _start_distribution():
 
     for path in distribution.get_python_paths():
         sys.path.insert(0, path)
-        if path not in python_paths:
-            python_paths.append(path)
+        while path in python_paths:
+            python_paths.remove(path)
+        python_paths.insert(0, path)
 
     for path in distribution.get_sys_paths():
         sys.path.insert(0, path)

--- a/start.py
+++ b/start.py
@@ -811,7 +811,6 @@ def _start_distribution():
     #   already in PYTHONPATH
     addons_dir = Path(get_addons_dir())
     dependencies_dir = Path(get_dependencies_dir())
-    dep_dir_idx = None
     python_paths = []
     idx = 0
     for path in os.getenv("PYTHONPATH", "").split(os.pathsep):

--- a/start.py
+++ b/start.py
@@ -810,7 +810,8 @@ def _start_distribution():
     dependencies_dir = Path(get_dependencies_dir())
     dep_dir_idx = None
     python_paths = []
-    for idx, path in enumerate(os.getenv("PYTHONPATH", "").split(os.pathsep)):
+    idx = 0
+    for path in os.getenv("PYTHONPATH", "").split(os.pathsep):
         if not path:
             continue
 
@@ -826,6 +827,7 @@ def _start_distribution():
                 dep_dir_idx = idx
             continue
         python_paths.append(path)
+        idx += 1
 
     addon_paths, dep_package_path = distribution.get_python_paths()
 

--- a/start.py
+++ b/start.py
@@ -801,7 +801,11 @@ def _start_distribution():
     os.environ["AYON_BUNDLE_NAME"] = project_bundle_name
     os.environ["AYON_STUDIO_BUNDLE_NAME"] = studio_bundle_name
 
-    # TODO probably remove paths to other addons?
+    # Remove any path leading to addons or dependecy packages directory
+    # - makes sure that any addon in PYTHONPATH is removed, addons from
+    #   current bundle are added below.
+    # - also make sure to keep order of dependency package if there is any
+    #   already in PYTHONPATH
     addons_dir = Path(get_addons_dir())
     dependencies_dir = Path(get_dependencies_dir())
     dep_dir_idx = None
@@ -811,11 +815,12 @@ def _start_distribution():
             continue
 
         p_path = Path(path)
-        # Ignore addons
+        # Ignore addons directories
         if p_path.is_relative_to(addons_dir):
             continue
 
-        # Ignore dependencies dir and store index of the path
+        # Ignore dependencies dir and store index of the path to keep it in
+        #   same order
         if p_path.is_relative_to(dependencies_dir):
             if dep_dir_idx is None:
                 dep_dir_idx = idx


### PR DESCRIPTION
## Changelog Description
Make sure to prepend the paths to PYTHONPATH.

## Additional info
We're addin them with correct order in `sys.path` which works for AYON launcher process but any child process that is not AYON launcher process will use `PYTHONPATH` which might have paths from some of previous processes.

## Testing notes:
Not sure how to test it, we discovered this issue during project bundles testing which was fixed with https://github.com/ynput/ayon-core/pull/1710 .
