### PR TITLE
Chore: Disk mapping is getting settings correctly

### DIFF
--- a/start.py
+++ b/start.py
@@ -348,7 +348,7 @@ if not os.getenv("SSL_CERT_FILE"):
 elif os.getenv("SSL_CERT_FILE") != certifi.where():
     _print("--- your system is set to use custom CA certificate bundle.")
 
-import ayon_api
+import ayon_api  # noqa E402
 from ayon_api import (  # noqa E402
     get_base_url,
     set_default_settings_variant,


### PR DESCRIPTION
## Changelog Description
Pass both studio bundle name and project bundle name to settings query when getting disk mappings.

## Additional info
Project bundle name was passed where should be passed studio bundle name, this makes sure that studio and project bundle name are both passed (if are both specified).

## Testing notes:
1. Disk mapping works for project bundles and AYON server 1.14.0 .

NOTE: AYON server 1.14.1 does add support to pass project bundle name as studio bundle name because of this bug, but it should change.