### PR TITLE
Ensure `studio_bundle_to_use` is not None before accessing `is_dev` a…

### DIFF
--- a/common/ayon_common/distribution/control.py
+++ b/common/ayon_common/distribution/control.py
@@ -1769,7 +1769,7 @@ class AYONDistribution:
         if not self._project_bundle:
             # Force to use studio bundle as project bundle in dev mode
             studio_bundle = self.studio_bundle_to_use
-            if studio_bundle and studio_bundle.is_dev:
+            if not studio_bundle or studio_bundle.is_dev:
                 self._project_bundle = studio_bundle
                 return self._project_bundle
 


### PR DESCRIPTION
Ensure `studio_bundle_to_use` is not None before accessing `is_dev` and crashing the app. Now warning message properly displays.

## Changelog Description
Small change but if studio_bundle is not initialized & were in dev mode or even not well get a crash.

## Additional info
Its 2 line of code... my 1st PR wop wop!

## Testing notes:
1. start new ayon server
2. create nothing
3. start laucher - crash.
