### PR TITLE
Windows app description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "AYON"
 requires-python = "==3.11.9"
 version = "1.5.5-dev"
-description = "Open VFX and Animation pipeline with support."
+description = "AYON Desktop Client"
 authors = [
     {name = "Ynput s.r.o.", email = "info@ynput.io"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "AYON"
 requires-python = "==3.11.9"
 version = "1.5.5-dev"
-description = "AYON Desktop Client"
+description = "AYON launcher"
 authors = [
     {name = "Ynput s.r.o.", email = "info@ynput.io"}
 ]

--- a/shim/shim/Cargo.toml
+++ b/shim/shim/Cargo.toml
@@ -3,6 +3,9 @@ name = "shim"
 version = "1.1.0"
 edition = "2021"
 
+[package.metadata.winres]
+FileDescription = "AYON shim"
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Changelog Description
Change application description so windows task manager shows reasonable application label.

## Additional info
Description from `pyproject.toml` is used as application description which is showed in task manger on window, which is the reason why it had to change. Shim on the other side did not define description at all, which cause that `shim` was showed in task manager.

## Testing notes:
1. Build ayon launcher, upload to server and use it in bundle.
2. Deploy shim from the launcher (in case you already have the shim installed from other PRs testings).
3. Run the shim.
4. Both shim and launcher processes should have either `AYON shim` or `AYON Desktop Client` name in task manager.