### PR TITLE
Login dialog: Go to edit mode if api key is invalid

### DIFF
--- a/common/ayon_common/connection/ui/login_window.py
+++ b/common/ayon_common/connection/ui/login_window.py
@@ -576,6 +576,7 @@ class ServerLoginWindow(QtWidgets.QDialog):
 
         if self._url_is_valid and api_key and logged_in:
             self._set_message("<b>Invalid API key</b>")
+            self._on_username_edit_click()
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -809,6 +810,7 @@ class ServerLoginWindow(QtWidgets.QDialog):
 
         self._set_credentials_valid(False)
         self._set_message("<b>Invalid API key</b>")
+        self._on_username_edit_click()
 
     def _on_login_click(self):
         self._login()


### PR DESCRIPTION
## Changelog Description
Enter edit mode if API key is invalid.

## Additional info
Skip view mode in case api key is invalid and enter edit mode, there is nothing else to do if api key is invalid than login.

## Testing notes:
1. If api key is invalid it does enter edit mode (enter username and password).

Follow up for https://github.com/ynput/ayon-launcher/pull/307
