### PR TITLE
Shim deployment enhancement

### DIFF
--- a/common/ayon_common/distribution/__init__.py
+++ b/common/ayon_common/distribution/__init__.py
@@ -4,6 +4,7 @@ from .exceptions import (
 )
 from .control import AYONDistribution
 from .utils import (
+    show_failed_shim_deployment,
     show_missing_permissions,
     show_blocked_auto_update,
     show_missing_bundle_information,
@@ -18,6 +19,7 @@ __all__ = (
 
     "AYONDistribution",
 
+    "show_failed_shim_deployment",
     "show_missing_permissions",
     "show_blocked_auto_update",
     "show_missing_bundle_information",

--- a/common/ayon_common/distribution/utils.py
+++ b/common/ayon_common/distribution/utils.py
@@ -1,10 +1,15 @@
 import os
 import json
 import subprocess
+import platform
 import tempfile
 from typing import Optional
 
-from ayon_common.utils import get_launcher_storage_dir, get_ayon_launch_args
+from ayon_common.utils import (
+    get_launcher_storage_dir,
+    get_launcher_local_dir,
+    get_ayon_launch_args,
+)
 
 
 def get_addons_dir():
@@ -63,6 +68,23 @@ def show_missing_permissions():
         ),
     )
 
+
+def show_failed_shim_deployment(message: str | None = None) -> None:
+    if message is None:
+        platform_name = platform.system().lower()
+        if platform_name == "darwin":
+            shim_path = "/Applications/AYON.app"
+        else:
+            shim_path = get_launcher_local_dir("shim")
+        message = (
+            f"Failed to deploy AYON shim. Removing '{shim_path}' might help"
+            " to resolve the issue."
+        )
+
+    _show_message_dialog(
+        "AYON distribution - Failed to deploy shims",
+        message,
+    )
 
 def show_blocked_auto_update(launcher: bool):
     if launcher:

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -28,7 +28,7 @@ IMPLEMENTED_ARCHIVE_FORMATS = {
     ".zip", ".tar", ".tgz", ".tar.gz", ".tar.xz", ".tar.bz2"
 }
 
-log = logging.Logger(__name__)
+log = logging.getLogger(__name__)
 
 ExecutablesInfo = Dict[str, Any]
 
@@ -948,7 +948,10 @@ def _deploy_shim_windows(
         try:
             _move_dir_content(shim_root, old_shim_root)
         except Exception as exc:
-            log.error("Failed to rename existing shim.", exc_info=True)
+            log.error(
+                "Failed to move existing shim content to backup.",
+                exc_info=True
+            )
             raise ShimDeploymentError(
                 "Failed to update shim executable."
                 " Please close all running AYON processes and try to run"

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -3,6 +3,7 @@ import sys
 import platform
 import json
 import datetime
+import logging
 import subprocess
 import zipfile
 import re
@@ -27,7 +28,13 @@ IMPLEMENTED_ARCHIVE_FORMATS = {
     ".zip", ".tar", ".tgz", ".tar.gz", ".tar.xz", ".tar.bz2"
 }
 
+log = logging.Logger(__name__)
+
 ExecutablesInfo = Dict[str, Any]
+
+
+class ShimDeploymentError(Exception):
+    """Error related to deploying shim executable."""
 
 
 def _get_ayon_appdirs(*args):
@@ -900,6 +907,25 @@ def _find_next_tmp_shim_root(path: str) -> str:
         idx += 1
 
 
+def _move_dir_content(src_dir: str, dst_dir: str) -> None:
+    """Move a content of directory to another directory.
+
+    This is used to preserve existing directory content when deploying
+        a new shim version. In that case the source directory is used as cwd
+        for a process and cannot be renamed, but the content can be moved.
+
+    Args:
+        src_dir (str): Path to the source directory.
+        dst_dir (str): Path to the destination directory.
+
+    """
+    os.makedirs(dst_dir, exist_ok=True)
+    for name in os.listdir(src_dir):
+        src_path = os.path.join(src_dir, name)
+        dst_path = os.path.join(dst_dir, name)
+        os.rename(src_path, dst_path)
+
+
 def _deploy_shim_windows(
     installer_shim_root: str,
     create_desktop_icons: bool,
@@ -919,7 +945,16 @@ def _deploy_shim_windows(
     renamed = False
     if os.path.exists(shim_root):
         renamed = True
-        os.rename(shim_root, old_shim_root)
+        try:
+            _move_dir_content(shim_root, old_shim_root)
+        except Exception as exc:
+            log.error("Failed to rename existing shim.", exc_info=True)
+            raise ShimDeploymentError(
+                "Failed to update shim executable."
+                " Please close all running AYON processes and try to run"
+                f" {sys.executable}. If the problem persists, uninstall"
+                " AYON from applications."
+            ) from exc
 
     success = False
     try:
@@ -939,11 +974,12 @@ def _deploy_shim_windows(
         success = code == 0
     finally:
         if not success:
-            if os.path.exists(shim_root):
+            if os.path.exists(shim_root) and len(os.listdir(shim_root)) > 0:
                 shim_root_bk = _find_next_tmp_shim_root(shim_root)
-                os.rename(shim_root, shim_root_bk)
+                _move_dir_content(shim_root, shim_root_bk)
+
             if renamed:
-                os.rename(old_shim_root, shim_root)
+                _move_dir_content(old_shim_root, shim_root)
 
     return success
 

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -954,8 +954,8 @@ def _deploy_shim_windows(
             )
             raise ShimDeploymentError(
                 "Failed to update shim executable."
-                " Please close all running AYON processes and try to run"
-                f" {sys.executable}. If the problem persists, uninstall"
+                "\n\nPlease close all running AYON processes and try to run"
+                f" {sys.executable}.\n\nIf the problem persists, uninstall"
                 " AYON from applications."
             ) from exc
 
@@ -1004,8 +1004,8 @@ def _deploy_shim_linux(installer_shim_root: str) -> bool:
             log.error("Failed to remove old shim", exc_info=True)
             raise ShimDeploymentError(
                 "Failed to update shim executable."
-                " Please close all running AYON processes and try to run"
-                f" '{sys.executable}'. If the problem persists,"
+                "\n\nPlease close all running AYON processes and try to run"
+                f" '{sys.executable}'.\n\nIf the problem persists,"
                 f" remove old shim '{executable_root}'."
             ) from exc
 
@@ -1043,8 +1043,8 @@ def _deploy_shim_macos(installer_shim_root: str):
             app_path = "/".join(direct_path_parts)
             raise ShimDeploymentError(
                 "Failed to update shim executable."
-                " Please close all running AYON processes and try to run"
-                f" '{app_path}'. If the problem persists,"
+                "\n\nPlease close all running AYON processes and try to run"
+                f" '{app_path}'.\n\nIf the problem persists,"
                 f" remove '{ayon_app_path}' and re-run."
             ) from exc
 

--- a/common/ayon_common/utils.py
+++ b/common/ayon_common/utils.py
@@ -998,8 +998,13 @@ def _deploy_shim_linux(installer_shim_root: str) -> bool:
         try:
             shutil.rmtree(executable_root)
         except Exception as exc:
-            print(f"Failed to remove existing shim {exc}")
-            raise RuntimeError("Failed to remove existing AYON shim")
+            log.error("Failed to remove old shim", exc_info=True)
+            raise ShimDeploymentError(
+                "Failed to update shim executable."
+                " Please close all running AYON processes and try to run"
+                f" '{sys.executable}'. If the problem persists,"
+                f" remove old shim '{executable_root}'."
+            ) from exc
 
     os.makedirs(executable_root, exist_ok=True)
     extract_archive_file(
@@ -1026,8 +1031,19 @@ def _deploy_shim_macos(installer_shim_root: str):
         try:
             shutil.rmtree(ayon_app_path)
         except Exception as exc:
-            print(f"Failed to remove existing shim {exc}")
-            raise RuntimeError("Failed to remove existing shim")
+            log.error("Failed to remove old shim", exc_info=True)
+            direct_path_parts = []
+            for name in sys.executable.split("/"):
+                if name == "Contents":
+                    break
+                direct_path_parts.append(name)
+            app_path = "/".join(direct_path_parts)
+            raise ShimDeploymentError(
+                "Failed to update shim executable."
+                " Please close all running AYON processes and try to run"
+                f" '{app_path}'. If the problem persists,"
+                f" remove '{ayon_app_path}' and re-run."
+            ) from exc
 
     filepath = os.path.join(installer_shim_root, "shim.dmg")
     # Attach dmg file and read plist output (bytes)

--- a/start.py
+++ b/start.py
@@ -377,6 +377,7 @@ from ayon_common.connection.credentials import (  # noqa E402
 from ayon_common.distribution import (  # noqa E402
     AYONDistribution,
     BundleNotFoundError,
+    show_failed_shim_deployment,
     show_missing_bundle_information,
     show_blocked_auto_update,
     show_missing_permissions,
@@ -387,6 +388,7 @@ from ayon_common.distribution import (  # noqa E402
 from ayon_common.utils import (  # noqa E402
     store_current_executable_info,
     deploy_ayon_launcher_shims,
+    ShimDeploymentError,
     get_local_site_id,
     get_launcher_local_dir,
     get_launcher_storage_dir,
@@ -828,10 +830,21 @@ def init_launcher_executable(ensure_protocol_is_registered=False):
     """
     create_desktop_icons = "--create-desktop-icons" in sys.argv
     store_current_executable_info()
-    deploy_ayon_launcher_shims(
-        ensure_protocol_is_registered=ensure_protocol_is_registered,
-        create_desktop_icons=create_desktop_icons,
-    )
+    try:
+        deploy_ayon_launcher_shims(
+            ensure_protocol_is_registered=ensure_protocol_is_registered,
+            create_desktop_icons=create_desktop_icons,
+        )
+    except ShimDeploymentError as exc:
+        if not HEADLESS_MODE_ENABLED:
+            show_failed_shim_deployment(exc)
+        sys.exit(1)
+    except Exception as exc:
+        _print("Unexpected error during shim deployment.")
+        traceback.print_exception(*sys.exc_info())
+        if not HEADLESS_MODE_ENABLED:
+            show_failed_shim_deployment()
+        sys.exit(1)
 
 
 def fill_pythonpath():

--- a/start.py
+++ b/start.py
@@ -839,7 +839,7 @@ def init_launcher_executable(ensure_protocol_is_registered=False):
         if not HEADLESS_MODE_ENABLED:
             show_failed_shim_deployment(str(exc))
         sys.exit(1)
-    except Exception as exc:
+    except Exception:
         _print("Unexpected error during shim deployment.")
         traceback.print_exception(*sys.exc_info())
         if not HEADLESS_MODE_ENABLED:

--- a/start.py
+++ b/start.py
@@ -837,7 +837,7 @@ def init_launcher_executable(ensure_protocol_is_registered=False):
         )
     except ShimDeploymentError as exc:
         if not HEADLESS_MODE_ENABLED:
-            show_failed_shim_deployment(exc)
+            show_failed_shim_deployment(str(exc))
         sys.exit(1)
     except Exception as exc:
         _print("Unexpected error during shim deployment.")


### PR DESCRIPTION
## Changelog Description
Windows shim deployment should happen even if shim is used in running process and failed deployment of shim shows a message.

## Additional info
On windows the shim directory is not renamed, the content of old shim is moved to backup directory (which is allowed). In case something goes wrong a message that "shim deployment" failed is showed (with possible manual fix), instead of cx freeze scary error.

## Testing notes:
1. Create installer with this PR.
2. Upload the installer to server and use it in production bundle.
3. Downgrade shim in case you already have the new one -> can be installed from older AYON launchers (`..../AYON 1.5.4/shim/shim.exe`).
4. Start AYON from shortcut on desktop (that should lead to the shim).
5. Everything is smooth as butter.